### PR TITLE
Intelligent Muting Capability – SB-1506

### DIFF
--- a/student/src/main/webapp/ItemPreviewScripts/development.js
+++ b/student/src/main/webapp/ItemPreviewScripts/development.js
@@ -143,8 +143,10 @@ function getScreenshot(element, type /* image/png, image/jpeg */)
     type = type || 'image/png';
 
     // about:config - 'signed.applets.codebase_principal_support' needs to equal true
-    netscape.security.PrivilegeManager.enablePrivilege("UniversalXPConnect");
-
+    
+    //SB-1506-Intelligent-Muting.  Use enableComponents to support both SB 8.1 and 9.0 
+    Mozilla.enableComponents();
+    
     var doc = element.ownerDocument;
     var win = doc.defaultView;
 


### PR DESCRIPTION
**Intelligent Muting Capability – SB-1506**
Intelligent muting is a configuration (test level or proctor level) that allows the ability to (a) mute the entire test; (b) mute just passages; (c) mute just questions; or (d) don't mute anything. This was implemented with a new, custom tag (attribute) called brailleonly which is set to true for all item containers, or true for all passage containers, or both. This new attribute is only supported by JAWS 16+ and requires Braille mode to be active.
The brailleonly.js file that sets attribute brailleonly depends on the values of 'Mute System Volume' accommodation property derived from client_testtool table for given test. 