### PR TITLE
/checkApproval integration

### DIFF
--- a/student.library/pom.xml
+++ b/student.library/pom.xml
@@ -21,6 +21,7 @@
 		<item-scoring.version>1.1.0-SNAPSHOT</item-scoring.version>
 		<item-selection.version>0.0.1-SNAPSHOT</item-selection.version>
 		<tds-exam-client.version>0.0.1-SNAPSHOT</tds-exam-client.version>
+		<tds-assessment-client.version>0.0.1-SNAPSHOT</tds-assessment-client.version>
 		<tds-common-legacy.version>0.0.1-SNAPSHOT</tds-common-legacy.version>
 	</properties>
 
@@ -63,6 +64,11 @@
 			<groupId>org.opentestsystem.exam</groupId>
 			<artifactId>tds-exam-client</artifactId>
 			<version>${tds-exam-client.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.opentestsystem.assessment</groupId>
+			<artifactId>tds-assessment-client</artifactId>
+			<version>${tds-assessment-client.version}</version>
 		</dependency>
 
 		<!-- Start Dependency shared project -->
@@ -139,5 +145,5 @@
 			<artifactId>ResourceBundler</artifactId>
 			<version>${resource-bundler.version}</version>
 		</dependency>
-	</dependencies>
+    </dependencies>
 </project>

--- a/student.library/src/main/java/tds/student/sql/abstractions/AssessmentRepository.java
+++ b/student.library/src/main/java/tds/student/sql/abstractions/AssessmentRepository.java
@@ -1,0 +1,31 @@
+package tds.student.sql.abstractions;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+
+import java.util.List;
+
+import tds.accommodation.Accommodation;
+import tds.assessment.Assessment;
+
+/**
+ * Repository to interact with Assessment data
+ */
+public interface AssessmentRepository {
+  /**
+   * Retrieves an {@link tds.assessment.Assessment} from the assessment service by the assessment key
+   *
+   * @param clientName the current envrionment's client name
+   * @param key        the key of the {@link tds.assessment.Assessment}
+   * @return the fully populated {@link tds.assessment.Assessment}
+   * @throws ReturnStatusException
+   */
+  Assessment findAssessment(final String clientName, final String key) throws ReturnStatusException;
+
+  /**
+   * @param clientName    the current envrionment's client name
+   * @param assessmentKey the key of the {@link tds.assessment.Assessment}
+   * @return the list of all assessment {@link tds.accommodation.Accommodation}
+   * @throws ReturnStatusException
+   */
+  List<Accommodation> findAccommodations(final String clientName, final String assessmentKey) throws ReturnStatusException;
+}

--- a/student.library/src/main/java/tds/student/sql/abstractions/ExamRepository.java
+++ b/student.library/src/main/java/tds/student/sql/abstractions/ExamRepository.java
@@ -2,18 +2,21 @@ package tds.student.sql.abstractions;
 
 import TDS.Shared.Exceptions.ReturnStatusException;
 
+import java.util.List;
 import java.util.UUID;
 
 import tds.common.Response;
 import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
+import tds.exam.ExamAccommodation;
+import tds.exam.ExamApproval;
 import tds.exam.OpenExamRequest;
 
 /**
  * Repository to interact with exam data
  */
 public interface ExamRepository {
-
+    
   /**
    * Opens an exam
    *
@@ -22,7 +25,27 @@ public interface ExamRepository {
    * @throws ReturnStatusException if there is an unexpected response from the call
    */
   Response<Exam> openExam(final OpenExamRequest openExamRequest) throws ReturnStatusException;
-    
+
+  /**
+   * Fetches the approval status of the current exam
+   *
+   * @param examId    the id of the exam
+   * @param sessionId the id of the session the exam is a part of
+   * @param browserId the id of the browser of the current session
+   * @return the {@link tds.exam.ExamApproval} containing the status information
+   * @throws ReturnStatusException
+   */
+  Response<ExamApproval> getApproval(final UUID examId, final UUID sessionId, final UUID browserId) throws ReturnStatusException;
+
+  /**
+   * Fetches the collection of approved {@link tds.exam.ExamAccommodation}s for an exam
+   *
+   * @param examId the id of the {@link tds.exam.Exam}
+   * @return the list of approved {@link tds.exam.ExamAccommodation}s
+   * @throws ReturnStatusException
+   */
+  List<ExamAccommodation> findApprovedAccommodations(final UUID examId) throws ReturnStatusException;
+
   /**
    * Creates a request for the exam service to approve {@link tds.exam.ExamAccommodation}s
    *

--- a/student/src/main/java/tds/student/services/remote/RemoteAccommodationsService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteAccommodationsService.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import tds.accommodation.Accommodation;
-import tds.accommodation.Dependency;
+import tds.accommodation.AccommodationDependency;
 import tds.assessment.Assessment;
 import tds.assessment.Segment;
 import tds.exam.ApproveAccommodationsRequest;
@@ -122,7 +122,7 @@ public class RemoteAccommodationsService implements IAccommodationsService {
       approvedExamAccommodationMap.put(examAccommodation.getCode(), examAccommodation);
     }
     
-    /* We need to filter only approve ExamAccommodations - although the Assessment acccommodations contain
+    /* We need to filter only approve ExamAccommodations - although the Assessment accommodations contain
        the majority of the accommodation metadata  */
     for (Accommodation accommodation : assessmentAccommodations) {
       // Filter only approved accommodations
@@ -141,7 +141,7 @@ public class RemoteAccommodationsService implements IAccommodationsService {
         }
       
         /* AccommodationService [399-400] - If this isn't a guest session, then no need to check isDisabledOnGuest flag */
-        if (!isGuestSession || (isGuestSession && !accommodation.isDisableOnGuestSession())) {
+        if (!isGuestSession || !accommodation.isDisableOnGuestSession()) {
           // Create accommodations type and value - these will be used by the UI between checkApproval and startTest
           retAccommodations.create(accommodation.getType(), accommodation.getCode(), accommodation.getValue(), accommodation.isVisible(),
             accommodation.isSelectable(), accommodation.isAllowChange(), accommodation.isStudentControl(), accommodation.getDependsOnToolType(),
@@ -154,7 +154,7 @@ public class RemoteAccommodationsService implements IAccommodationsService {
     if (!segmentPositionToAccommodations.isEmpty()) {
       Accommodations assessmentAccommodation = segmentPositionToAccommodations.get(ASSESSMENT_POSITION);
     
-      for (Dependency assessmentDependency : assessment.getAccommodationDependencies()) {
+      for (AccommodationDependency assessmentDependency : assessment.getAccommodationDependencies()) {
         assessmentAccommodation.AddDependency(assessmentDependency.getIfType(), assessmentDependency.getIfValue(),
           assessmentDependency.getThenType(), assessmentDependency.getThenValue(), assessmentDependency.isDefault());
       }

--- a/student/src/main/java/tds/student/services/remote/RemoteAccommodationsService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteAccommodationsService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,8 +15,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import tds.accommodation.Accommodation;
+import tds.accommodation.Dependency;
+import tds.assessment.Assessment;
+import tds.assessment.Segment;
 import tds.exam.ApproveAccommodationsRequest;
+import tds.exam.ExamAccommodation;
 import tds.student.services.abstractions.IAccommodationsService;
+import tds.student.sql.abstractions.AssessmentRepository;
 import tds.student.sql.abstractions.ExamRepository;
 import tds.student.sql.data.Accommodations;
 import tds.student.sql.data.OpportunityInstance;
@@ -27,32 +34,35 @@ public class RemoteAccommodationsService implements IAccommodationsService {
   private final boolean isRemoteExamCallsEnabled;
   private final boolean isLegacyCallsEnabled;
   private final ExamRepository examRepository;
-
+  private final AssessmentRepository assessmentRepository;
+  private static final int ASSESSMENT_POSITION = 0;
+  
   @Autowired
   public RemoteAccommodationsService(
     @Qualifier("legacyAccommodationsService") IAccommodationsService legacyAccommodationsService,
     @Value("${tds.exam.remote.enabled}") Boolean remoteExamCallsEnabled,
     @Value("${tds.exam.legacy.enabled}") Boolean legacyCallsEnabled,
-    ExamRepository examRepository) {
-
+    ExamRepository examRepository,
+    AssessmentRepository assessmentRepository) {
+    
     if (!remoteExamCallsEnabled && !legacyCallsEnabled) {
       throw new IllegalStateException("Remote and legacy calls are both disabled.  Please check progman configuration");
     }
-
+    
     this.isRemoteExamCallsEnabled = remoteExamCallsEnabled;
     this.legacyAccommodationsService = legacyAccommodationsService;
     this.isLegacyCallsEnabled = legacyCallsEnabled;
     this.examRepository = examRepository;
+    this.assessmentRepository = assessmentRepository;
   }
-
+  
   @Override
   public List<Accommodations> getTestee(String testKey, boolean isGuestSession, long testeeKey) throws ReturnStatusException {
     return legacyAccommodationsService.getTestee(testKey, isGuestSession, testeeKey);
   }
-
+  
   @Override
   public void approve(OpportunityInstance oppInstance, List<String> segmentsAccommodationData) throws ReturnStatusException {
-
     if (segmentsAccommodationData == null) {
       return;
     }
@@ -60,22 +70,114 @@ public class RemoteAccommodationsService implements IAccommodationsService {
     if (isLegacyCallsEnabled) {
       legacyAccommodationsService.approve(oppInstance, segmentsAccommodationData);
     }
-
+    
     if (!isRemoteExamCallsEnabled) {
       return;
     }
-
+    
     ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(oppInstance.getSessionKey(), oppInstance.getExamBrowserKey(),
       parseSegmentAccommodationStrings(segmentsAccommodationData));
-
+    
     examRepository.approveAccommodations(oppInstance.getExamId(), request);
   }
   
   @Override
-  public List<Accommodations> getApproved(OpportunityInstance opportunityInstance, String testKey, boolean isGuestSession) throws ReturnStatusException {
-    return legacyAccommodationsService.getApproved(opportunityInstance, testKey, isGuestSession);
+  public List<Accommodations> getApproved(final OpportunityInstance opportunityInstance, final String testKey,
+                                          final boolean isGuestSession) throws ReturnStatusException {
+    List<Accommodations> accommodations = null;
+    
+    if (isLegacyCallsEnabled) {
+      accommodations = legacyAccommodationsService.getApproved(opportunityInstance, testKey, isGuestSession);
+    }
+    
+    if (!isRemoteExamCallsEnabled) {
+      return accommodations;
+    }
+    /* AccommodationService [192] */
+    Assessment assessment = assessmentRepository.findAssessment(opportunityInstance.getExamClientName(), testKey);
+    // Contains all approved accommodations for this exam, for the entire assessment and individual segments
+    /* AccommodationService [194] */
+    List<ExamAccommodation> examAccommodationResponse = examRepository.findApprovedAccommodations(opportunityInstance.getExamId());
+    /* [396] This should contain accommodations for the entire assessment and its individual segments. */
+    // Contains all accommodation data
+    List<Accommodation> assessmentAccommodationsResponse = assessmentRepository.findAccommodations(opportunityInstance.getExamClientName(), testKey);
+    
+    return mapExamAccommodationsToLegacyAccommodations(assessment, assessmentAccommodationsResponse, examAccommodationResponse, isGuestSession);
   }
   
+  /* This method is a port of AccommodationService.getTestSegments() between [398 - 426] with some logic located in getApproved()
+  *  The "Accommodations" class is what the legacy code will use to create the TDS-Student-Accs cookie */
+  private List<Accommodations> mapExamAccommodationsToLegacyAccommodations(final Assessment assessment, final List<Accommodation> assessmentAccommodations,
+                                                     final List<ExamAccommodation> approvedExamAccommodations, final boolean isGuestSession) {
+    // accCode -> ExamAccommodation
+    Map<String, ExamAccommodation> approvedExamAccommodationMap = new HashMap<>();
+    // segmentPosition -> legacy Accommodations object (per segment + assessment)
+    Map<Integer, Accommodations> segmentPositionToAccommodations = new HashMap<>();
+    Accommodations retAccommodations;
+    ExamAccommodation approvedExamAccommodation;
+    int segmentPosition;
+    
+    // Map the accommodation keys (code) to their exam accommodations for quick lookup
+    for (ExamAccommodation examAccommodation : approvedExamAccommodations) {
+      approvedExamAccommodationMap.put(examAccommodation.getCode(), examAccommodation);
+    }
+    
+    /* We need to filter only approve ExamAccommodations - although the Assessment acccommodations contain
+       the majority of the accommodation metadata  */
+    for (Accommodation accommodation : assessmentAccommodations) {
+      // Filter only approved accommodations
+      approvedExamAccommodation = approvedExamAccommodationMap.get(accommodation.getCode());
+    
+      if (approvedExamAccommodation != null && approvedExamAccommodation.getType().equalsIgnoreCase(accommodation.getType())) {
+        segmentPosition = accommodation.getSegmentPosition();
+        retAccommodations = segmentPositionToAccommodations.get(segmentPosition);
+      
+        // If there are no Accommodations created for this segment position, we need to create one.
+        if (retAccommodations == null) {
+          // Accommodation context is either the segmentId or assessmentId, depending on whether the accommodation is
+          // segment specific or global to the assessment
+          retAccommodations = new Accommodations(segmentPosition, accommodation.getContext(), getLabelForAssessmentOrSegment(segmentPosition, assessment));
+          segmentPositionToAccommodations.put(segmentPosition, retAccommodations);
+        }
+      
+        /* AccommodationService [399-400] - If this isn't a guest session, then no need to check isDisabledOnGuest flag */
+        if (!isGuestSession || (isGuestSession && !accommodation.isDisableOnGuestSession())) {
+          // Create accommodations type and value - these will be used by the UI between checkApproval and startTest
+          retAccommodations.create(accommodation.getType(), accommodation.getCode(), accommodation.getValue(), accommodation.isVisible(),
+            accommodation.isSelectable(), accommodation.isAllowChange(), accommodation.isStudentControl(), accommodation.getDependsOnToolType(),
+            accommodation.isDisableOnGuestSession(), accommodation.isDefaultAccommodation(), accommodation.isAllowCombine(), accommodation.isSelectable());
+        }
+      }
+    }
+  
+    // Populate the accommodation dependencies for the *assessment* accommodation
+    if (!segmentPositionToAccommodations.isEmpty()) {
+      Accommodations assessmentAccommodation = segmentPositionToAccommodations.get(ASSESSMENT_POSITION);
+    
+      for (Dependency assessmentDependency : assessment.getAccommodationDependencies()) {
+        assessmentAccommodation.AddDependency(assessmentDependency.getIfType(), assessmentDependency.getIfValue(),
+          assessmentDependency.getThenType(), assessmentDependency.getThenValue(), assessmentDependency.isDefault());
+      }
+    }
+    
+    return new ArrayList<>(segmentPositionToAccommodations.values());
+  }
+
+  private String getLabelForAssessmentOrSegment(final int position, final Assessment assessment) {
+    // Position of zero is an assessment
+    if (position == ASSESSMENT_POSITION) {
+      return assessment.getLabel();
+    }
+    
+    String segmentLabel = null;
+    for (Segment segment : assessment.getSegments()) {
+      if (segment.getPosition() == position) {
+        segmentLabel = segment.getLabel();
+      }
+    }
+    
+    return segmentLabel;
+  }
   
   private Map<Integer, Set<String>> parseSegmentAccommodationStrings(List<String> segmentsAccommodationData) {
     // In format 0#TDS_Acc1,TDS_Test,ENU

--- a/student/src/main/java/tds/student/sql/repository/RemoteAssessmentRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/RemoteAssessmentRepository.java
@@ -1,0 +1,82 @@
+package tds.student.sql.repository;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+import tds.accommodation.Accommodation;
+import tds.assessment.Assessment;
+import tds.student.sql.abstractions.AssessmentRepository;
+
+@Repository
+public class RemoteAssessmentRepository implements AssessmentRepository {
+  private final RestTemplate restTemplate;
+  private final String assessmentUrl;
+
+  @Autowired
+  public RemoteAssessmentRepository(@Qualifier("integrationRestTemplate") final RestTemplate restTemplate,
+                              @Value("${tds.assessment.remote.url}") final String assessmentUrl) {
+    this.restTemplate = restTemplate;
+    this.assessmentUrl = assessmentUrl;
+  }
+
+  @Override
+  public Assessment findAssessment(final String clientName, final String key) throws ReturnStatusException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+    HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+    ResponseEntity<Assessment> responseEntity;
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/assessments/%s", assessmentUrl, clientName, key));
+
+    try {
+      responseEntity = restTemplate.exchange(
+        builder.build().toUri(),
+        HttpMethod.GET,
+        requestHttpEntity,
+        new ParameterizedTypeReference<Assessment>() {
+        });
+    } catch (RestClientException rce) {
+      throw new ReturnStatusException(rce);
+    }
+
+    return responseEntity.getBody();
+  }
+
+  @Override
+  public List<Accommodation> findAccommodations(final String clientName, final String assessmentKey) throws ReturnStatusException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+    HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+    ResponseEntity<List<Accommodation>> responseEntity;
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/assessments/accommodations", assessmentUrl, clientName))
+      .queryParam("assessmentKey", assessmentKey);
+
+    try {
+      responseEntity = restTemplate.exchange(
+        builder.build().toUri(),
+        HttpMethod.GET,
+        requestHttpEntity,
+        new ParameterizedTypeReference<List<Accommodation>>() {
+        });
+    } catch (RestClientException rce) {
+      throw new ReturnStatusException(rce);
+    }
+
+    return responseEntity.getBody();
+  }
+}

--- a/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
@@ -46,7 +46,7 @@ public class RemoteExamRepository implements ExamRepository {
     this.examUrl = examUrl;
     this.objectMapper = objectMapper;
   }
-
+  
   @Override
   public Response<Exam> openExam(final OpenExamRequest openExamRequest) throws ReturnStatusException {
     HttpEntity<OpenExamRequest> requestHttpEntity = new HttpEntity<>(openExamRequest);
@@ -86,16 +86,66 @@ public class RemoteExamRepository implements ExamRepository {
       throw new ReturnStatusException(e);
     }
   }
-
+  
+  @Override
+  public Response<ExamApproval> getApproval(final UUID examId, final UUID sessionId, final UUID browserId) throws ReturnStatusException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+    ResponseEntity<Response<ExamApproval>> responseEntity;
+    
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/approval", examUrl, examId))
+        .queryParam("sessionId", sessionId)
+        .queryParam("browserId", browserId);
+    
+    try {
+      responseEntity = restTemplate.exchange(
+          builder.build().encode().toUri(),
+          HttpMethod.GET,
+          requestHttpEntity,
+          new ParameterizedTypeReference<Response<ExamApproval>>() {
+          });
+    } catch (RestClientException rce) {
+      throw new ReturnStatusException(rce);
+    }
+    
+    return responseEntity.getBody();
+  }
+  
+  @Override
+  public List<ExamAccommodation> findApprovedAccommodations(UUID examId) throws ReturnStatusException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+    ResponseEntity<List<ExamAccommodation>> responseEntity;
+    
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/accommodations/approved", examUrl, examId));
+    
+    try {
+      responseEntity = restTemplate.exchange(
+          builder.build().encode().toUri(),
+          HttpMethod.GET,
+          requestHttpEntity,
+          new ParameterizedTypeReference<List<ExamAccommodation>>() {
+          });
+    } catch (RestClientException rce) {
+      throw new ReturnStatusException(rce);
+    }
+    
+    return responseEntity.getBody();
+  }
+  
   @Override
   public void approveAccommodations(UUID examId, ApproveAccommodationsRequest approveAccommodationsRequest) throws ReturnStatusException {
     HttpHeaders headers = new HttpHeaders();
     headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
     headers.setContentType(MediaType.APPLICATION_JSON);
     HttpEntity<?> requestHttpEntity = new HttpEntity<>(approveAccommodationsRequest, headers);
-
+    
     UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/accommodations", examUrl, examId));
-
+    
     try {
       restTemplate.exchange(
         builder.build().toUri(),

--- a/student/src/main/java/tds/student/web/handlers/MasterShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/MasterShellHandler.java
@@ -108,6 +108,7 @@ public class MasterShellHandler extends TDSHandler
   private static final Logger    _logger = LoggerFactory.getLogger (MasterShellHandler.class);
 
   @Autowired
+  @Qualifier("integrationAccommodationsService")
   private IAccommodationsService _accsService;
 
   @Autowired

--- a/student/src/main/resources/root-context.xml
+++ b/student/src/main/resources/root-context.xml
@@ -46,6 +46,7 @@
 				<beans:entry key="tds.exam.remote.enabled" value="${tds.exam.remote.enabled:false}" />
 				<beans:entry key="tds.exam.legacy.enabled" value="${tds.exam.legacy.enabled:true}" />
 				<beans:entry key="tds.exam.remote.url" value="${tds.exam.remote.url}" />
+				<beans:entry key="tds.assessment.remote.url" value="${tds.assessment.remote.url}" />
 			</util:map>
 
 		</beans:constructor-arg>

--- a/student/src/test/java/tds/student/services/remote/RemoteAccommodationsServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteAccommodationsServiceTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 import tds.accommodation.Accommodation;
-import tds.accommodation.Dependency;
+import tds.accommodation.AccommodationDependency;
 import tds.assessment.Algorithm;
 import tds.assessment.Assessment;
 import tds.assessment.Segment;
@@ -106,7 +106,7 @@ public class RemoteAccommodationsServiceTest {
         OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
           examId, UUID.randomUUID(), clientName);
     
-        Dependency dependency = new Dependency.Builder(assessmentId)
+        AccommodationDependency dependency = new AccommodationDependency.Builder(assessmentId)
           .withIfType("Language")
           .withIfValue("ELA")
           .withThenType("Masking")
@@ -167,7 +167,7 @@ public class RemoteAccommodationsServiceTest {
         OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
           examId, UUID.randomUUID(), clientName);
     
-        Dependency dependency = new Dependency.Builder(assessmentId)
+        AccommodationDependency dependency = new AccommodationDependency.Builder(assessmentId)
           .withIfType("Language")
           .withIfValue("ELA")
           .withThenType("Masking")
@@ -251,8 +251,8 @@ public class RemoteAccommodationsServiceTest {
         final UUID examId = UUID.randomUUID();
         OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
           examId, UUID.randomUUID(), clientName);
-        
-        Dependency dependency = new Dependency.Builder(assessmentId)
+    
+        AccommodationDependency dependency = new AccommodationDependency.Builder(assessmentId)
           .withIfType("Language")
           .withIfValue("ELA")
           .withThenType("Masking")

--- a/student/src/test/java/tds/student/services/remote/RemoteAccommodationsServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteAccommodationsServiceTest.java
@@ -7,19 +7,32 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import tds.accommodation.Accommodation;
+import tds.accommodation.Dependency;
+import tds.assessment.Algorithm;
+import tds.assessment.Assessment;
+import tds.assessment.Segment;
 import tds.exam.ApproveAccommodationsRequest;
+import tds.exam.ExamAccommodation;
 import tds.student.services.abstractions.IAccommodationsService;
+import tds.student.sql.abstractions.AssessmentRepository;
 import tds.student.sql.abstractions.ExamRepository;
+import tds.student.sql.data.AccommodationType;
+import tds.student.sql.data.AccommodationValue;
+import tds.student.sql.data.Accommodations;
 import tds.student.sql.data.OpportunityInstance;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoteAccommodationsServiceTest {
@@ -31,9 +44,13 @@ public class RemoteAccommodationsServiceTest {
     @Mock
     private ExamRepository mockExamRepository;
     
+    @Mock
+    private AssessmentRepository mockAssessmentRepository;
+    
     @Before
     public void setup() {
-        service = new RemoteAccommodationsService(legacyAccommodationsService, true, true, mockExamRepository);
+        service = new RemoteAccommodationsService(legacyAccommodationsService, true, true, mockExamRepository,
+            mockAssessmentRepository);
     }
     
     @Test
@@ -78,5 +95,314 @@ public class RemoteAccommodationsServiceTest {
         service.approve(oppInstance, null);
         verify(legacyAccommodationsService, never()).approve(oppInstance, null);
         verify(mockExamRepository, never()).approveAccommodations(eq(oppInstance.getExamId()), (ApproveAccommodationsRequest) any());
+    }
+    
+    @Test
+    public void shouldApproveNothingForEmptyAssessmentAccommodations() throws ReturnStatusException {
+        final String assessmentKey = "assessment-key";
+        final String assessmentId = "assessment-id";
+        final String clientName = "SBAC_PT";
+        final UUID examId = UUID.randomUUID();
+        OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+          examId, UUID.randomUUID(), clientName);
+    
+        Dependency dependency = new Dependency.Builder(assessmentId)
+          .withIfType("Language")
+          .withIfValue("ELA")
+          .withThenType("Masking")
+          .withThenValue("Off")
+          .withIsDefault(true)
+          .build();
+    
+        Segment seg1 = new Segment("segmentKey1", Algorithm.ADAPTIVE_2);
+        seg1.setLabel("ELA Segment 1");
+        seg1.setSegmentId("segment-id-1");
+        seg1.setPosition(1);
+        Segment seg2 = new Segment("segmentKey2", Algorithm.ADAPTIVE_2);
+        seg2.setLabel("ELA Segment 2");
+        seg2.setSegmentId("segment-id-2");
+        seg2.setPosition(2);
+    
+        Assessment assessment = new Assessment();
+        assessment.setKey(assessmentKey);
+        assessment.setAssessmentId(assessmentId);
+        assessment.setLabel("ELA Test");
+        assessment.setAccommodationDependencies(Arrays.asList(dependency));
+        assessment.setSegments(Arrays.asList(seg1, seg2));
+        
+        ExamAccommodation assessmentExamAcc1 = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withCode("AccType1")
+          .withType("AccType1")
+          .build();
+        ExamAccommodation segment1ExamAcc = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withCode("AccType2")
+          .withType("AccType2")
+          .build();
+        ExamAccommodation segment2ExamAcc = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withCode("AccType3")
+          .withType("AccType3")
+          .build();
+    
+        when(legacyAccommodationsService.getApproved(oppInstance, assessmentKey, true)).thenReturn(new ArrayList<Accommodations>());
+        when(mockAssessmentRepository.findAccommodations(clientName, assessmentKey)).thenReturn(new ArrayList<Accommodation>());
+        when(mockAssessmentRepository.findAssessment(clientName, assessmentKey)).thenReturn(assessment);
+        when(mockExamRepository.findApprovedAccommodations(examId)).thenReturn(Arrays.asList(assessmentExamAcc1, segment1ExamAcc, segment2ExamAcc));
+    
+        List<Accommodations> retAccommodations = service.getApproved(oppInstance, assessmentKey, true);
+    
+        verify(legacyAccommodationsService).getApproved(oppInstance, assessmentKey, true);
+        verify(mockAssessmentRepository).findAccommodations(clientName, assessmentKey);
+        verify(mockAssessmentRepository).findAssessment(clientName, assessmentKey);
+        verify(mockExamRepository).findApprovedAccommodations(examId);
+    
+        assertThat(retAccommodations).isEmpty();
+    }
+    
+    @Test
+    public void shouldApproveNothingForEmptyExamAccommodations() throws ReturnStatusException {
+        final String assessmentKey = "assessment-key";
+        final String assessmentId = "assessment-id";
+        final String clientName = "SBAC_PT";
+        final UUID examId = UUID.randomUUID();
+        OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+          examId, UUID.randomUUID(), clientName);
+    
+        Dependency dependency = new Dependency.Builder(assessmentId)
+          .withIfType("Language")
+          .withIfValue("ELA")
+          .withThenType("Masking")
+          .withThenValue("Off")
+          .withIsDefault(true)
+          .build();
+    
+        Segment seg1 = new Segment("segmentKey1", Algorithm.ADAPTIVE_2);
+        seg1.setLabel("ELA Segment 1");
+        seg1.setSegmentId("segment-id-1");
+        seg1.setPosition(1);
+        Segment seg2 = new Segment("segmentKey2", Algorithm.ADAPTIVE_2);
+        seg2.setLabel("ELA Segment 2");
+        seg2.setSegmentId("segment-id-2");
+        seg2.setPosition(2);
+    
+        Assessment assessment = new Assessment();
+        assessment.setKey(assessmentKey);
+        assessment.setAssessmentId(assessmentId);
+        assessment.setLabel("ELA Test");
+        assessment.setAccommodationDependencies(Arrays.asList(dependency));
+        assessment.setSegments(Arrays.asList(seg1, seg2));
+    
+        Accommodation assessmentAcc1 = new Accommodation.Builder()
+          .withContext(assessmentId)
+          .withAccommodationType("AccType1")
+          .withAccommodationCode("AccCode1")
+          .withSegmentPosition(0)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation assessmentAcc2 = new Accommodation.Builder()
+          .withContext(assessmentId)
+          .withAccommodationType("AccType2")
+          .withAccommodationCode("AccCode2")
+          .withSegmentPosition(0)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation segment1Acc = new Accommodation.Builder()
+          .withContext(seg1.getSegmentId())
+          .withAccommodationType("AccType3")
+          .withAccommodationCode("AccCode3")
+          .withSegmentPosition(1)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation segment2Acc = new Accommodation.Builder()
+          .withContext(seg2.getSegmentId())
+          .withAccommodationType("AccType4")
+          .withAccommodationCode("AccCode4")
+          .withSegmentPosition(2)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .build();
+        
+        when(legacyAccommodationsService.getApproved(oppInstance, assessmentKey, true)).thenReturn(new ArrayList<Accommodations>());
+        when(mockAssessmentRepository.findAccommodations(clientName, assessmentKey))
+          .thenReturn(Arrays.asList(assessmentAcc1, assessmentAcc2, segment1Acc, segment2Acc));
+        when(mockAssessmentRepository.findAssessment(clientName, assessmentKey)).thenReturn(assessment);
+        when(mockExamRepository.findApprovedAccommodations(examId)).thenReturn(new ArrayList<ExamAccommodation>());
+    
+        List<Accommodations> retAccommodations = service.getApproved(oppInstance, assessmentKey, true);
+    
+        verify(legacyAccommodationsService).getApproved(oppInstance, assessmentKey, true);
+        verify(mockAssessmentRepository).findAccommodations(clientName, assessmentKey);
+        verify(mockAssessmentRepository).findAssessment(clientName, assessmentKey);
+        verify(mockExamRepository).findApprovedAccommodations(examId);
+    
+        assertThat(retAccommodations).isEmpty();
+    }
+    
+    @Test
+    public void shouldGetAccommodationsForGuestSessionWithSegments() throws ReturnStatusException {
+        final String assessmentKey = "assessment-key";
+        final String assessmentId = "assessment-id";
+        final String clientName = "SBAC_PT";
+        final UUID examId = UUID.randomUUID();
+        OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+          examId, UUID.randomUUID(), clientName);
+        
+        Dependency dependency = new Dependency.Builder(assessmentId)
+          .withIfType("Language")
+          .withIfValue("ELA")
+          .withThenType("Masking")
+          .withThenValue("Off")
+          .withIsDefault(true)
+          .build();
+    
+        Segment seg1 = new Segment("segmentKey1", Algorithm.ADAPTIVE_2);
+        seg1.setLabel("ELA Segment 1");
+        seg1.setSegmentId("segment-id-1");
+        seg1.setPosition(1);
+        Segment seg2 = new Segment("segmentKey2", Algorithm.ADAPTIVE_2);
+        seg2.setLabel("ELA Segment 2");
+        seg2.setSegmentId("segment-id-2");
+        seg2.setPosition(2);
+        
+        Assessment assessment = new Assessment();
+        assessment.setKey(assessmentKey);
+        assessment.setAssessmentId(assessmentId);
+        assessment.setLabel("ELA Test");
+        assessment.setAccommodationDependencies(Arrays.asList(dependency));
+        assessment.setSegments(Arrays.asList(seg1, seg2));
+    
+        Accommodation assessmentAcc1 = new Accommodation.Builder()
+          .withContext(assessmentId)
+          .withAccommodationType("AccType1")
+          .withAccommodationCode("AccCode1")
+          .withSegmentPosition(0)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation assessmentAcc2 = new Accommodation.Builder()
+          .withContext(assessmentId)
+          .withAccommodationType("AccType2")
+          .withAccommodationCode("AccCode2")
+          .withSegmentPosition(0)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation assessmentAcc3 = new Accommodation.Builder()
+          .withContext(assessmentId)
+          .withAccommodationType("AccType3")
+          .withAccommodationCode("AccCode3")
+          .withSegmentPosition(0)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDisableOnGuestSession(true)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation segment1Acc = new Accommodation.Builder()
+          .withContext(seg1.getSegmentId())
+          .withAccommodationType("AccType4")
+          .withAccommodationCode("AccCode4")
+          .withSegmentPosition(1)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .withDependsOnToolType("Language")
+          .build();
+        Accommodation segment2Acc = new Accommodation.Builder()
+          .withContext(seg2.getSegmentId())
+          .withAccommodationType("AccType5")
+          .withAccommodationCode("AccCode5")
+          .withSegmentPosition(2)
+          .withAllowChange(true)
+          .withAllowCombine(false)
+          .build();
+    
+        ExamAccommodation assessmentExamAcc1 = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withCode(assessmentAcc1.getCode())
+          .withType(assessmentAcc1.getType())
+          .build();
+        ExamAccommodation badAssessmentExamAcc2 = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withCode("DifferentCode")
+          .withType(assessmentAcc2.getType())
+          .build();
+        ExamAccommodation disabledGuestAccom = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withType(assessmentAcc3.getType())
+          .withCode(assessmentAcc3.getCode())
+          .build();
+        ExamAccommodation segment1ExamAcc = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withType(segment1Acc.getType())
+          .withCode(segment1Acc.getCode())
+          .build();
+        ExamAccommodation segment2ExamAcc = new ExamAccommodation.Builder(UUID.randomUUID())
+          .withType(segment2Acc.getType())
+          .withCode(segment2Acc.getCode())
+          .build();
+        
+        when(legacyAccommodationsService.getApproved(oppInstance, assessmentKey, true)).thenReturn(new ArrayList<Accommodations>());
+        when(mockAssessmentRepository.findAccommodations(clientName, assessmentKey))
+          .thenReturn(Arrays.asList(assessmentAcc1, assessmentAcc2, assessmentAcc3, segment1Acc, segment2Acc));
+        when(mockAssessmentRepository.findAssessment(clientName, assessmentKey)).thenReturn(assessment);
+        when(mockExamRepository.findApprovedAccommodations(examId))
+          .thenReturn(Arrays.asList(assessmentExamAcc1, badAssessmentExamAcc2, disabledGuestAccom, segment1ExamAcc, segment2ExamAcc));
+        
+        List<Accommodations> retAccommodations = service.getApproved(oppInstance, assessmentKey, true);
+        
+        verify(legacyAccommodationsService).getApproved(oppInstance, assessmentKey, true);
+        verify(mockAssessmentRepository).findAccommodations(clientName, assessmentKey);
+        verify(mockAssessmentRepository).findAssessment(clientName, assessmentKey);
+        verify(mockExamRepository).findApprovedAccommodations(examId);
+        
+        assertThat(retAccommodations).hasSize(3);
+        
+        Accommodations assessmentAccommodations = null;
+        Accommodations segment1Accommodations = null;
+        Accommodations segment2Accommodations = null;
+        
+        for (Accommodations accommodations : retAccommodations) {
+            if (accommodations.getPosition() == 0) {
+                assessmentAccommodations = accommodations;
+            } else if (accommodations.getPosition() == 1) {
+                segment1Accommodations = accommodations;
+            } else if (accommodations.getPosition() == 2) {
+                segment2Accommodations = accommodations;
+            }
+        }
+        // Assessment Accommodations
+        assertThat(assessmentAccommodations.getLabel()).isEqualTo(assessment.getLabel());
+        assertThat(assessmentAccommodations.getId()).isEqualTo(assessment.getAssessmentId());
+        assertThat(assessmentAccommodations.getTypes()).hasSize(1);
+        
+        AccommodationType assessmentAccType = assessmentAccommodations.getTypes().get(0);
+        assertThat(assessmentAccType.getDependsOnToolType()).isEqualTo(assessmentAcc1.getDependsOnToolType());
+        assertThat(assessmentAccType.getName()).isEqualTo(assessmentAcc1.getType());
+        String assessmentAccCode = ((AccommodationValue) assessmentAccType.getValues().toArray()[0]).getCode();
+        assertThat(assessmentAccCode).isEqualTo(assessmentAcc1.getCode());
+        
+        // Segment 1 accommodations
+        assertThat(segment1Accommodations.getLabel()).isEqualTo(seg1.getLabel());
+        assertThat(segment1Accommodations.getId()).isEqualTo(seg1.getSegmentId());
+        assertThat(segment1Accommodations.getTypes()).hasSize(1);
+    
+        AccommodationType segment1AccType = segment1Accommodations.getTypes().get(0);
+        assertThat(segment1AccType.getDependsOnToolType()).isEqualTo(segment1Acc.getDependsOnToolType());
+        assertThat(segment1AccType.getName()).isEqualTo(segment1Acc.getType());
+        String seg1AccCode = ((AccommodationValue) segment1AccType.getValues().toArray()[0]).getCode();
+        assertThat(seg1AccCode).isEqualTo(segment1Acc.getCode());
+        
+        // Segment 2 accommodations
+        assertThat(segment2Accommodations.getLabel()).isEqualTo(seg2.getLabel());
+        assertThat(segment2Accommodations.getId()).isEqualTo(seg2.getSegmentId());
+        assertThat(segment2Accommodations.getTypes()).hasSize(1);
+    
+        AccommodationType segment2AccType = segment2Accommodations.getTypes().get(0);
+        assertThat(segment2AccType.getDependsOnToolType()).isEqualTo(segment2Acc.getDependsOnToolType());
+        assertThat(segment2AccType.getName()).isEqualTo(segment2Acc.getType());
+        String seg2AccCode = ((AccommodationValue) segment2AccType.getValues().toArray()[0]).getCode();
+        assertThat(seg2AccCode).isEqualTo(segment2Acc.getCode());
     }
 }


### PR DESCRIPTION
This PR includes implementation of /checkApproval, which serves two primary purposes:

1. Retrieves and validates the current status of the exam and
2. Retrieves all eligible exam accommodations

The accommodation metadata present in Accommodation/ExamAccommodations is then mapped to a legacy "Accommodations" class. This class is then used for creating the TDS-Student-Accs cookie, as well as the accommodation data returned to the client. 

There is some code in Assessment and Exam services that will accompany this PR. In particular, a list of accommodation Dependencies is now included in the assessment object. 