### PR TITLE
Start Exam Integration

### DIFF
--- a/student.library/src/main/java/tds/student/sql/abstractions/ExamRepository.java
+++ b/student.library/src/main/java/tds/student/sql/abstractions/ExamRepository.java
@@ -13,13 +13,14 @@ import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamSegment;
 import tds.exam.OpenExamRequest;
 
 /**
  * Repository to interact with exam data
  */
 public interface ExamRepository {
-  
+
   /**
    * Opens an exam
    *
@@ -28,7 +29,7 @@ public interface ExamRepository {
    * @throws ReturnStatusException if there is an unexpected response from the call
    */
   Response<Exam> openExam(final OpenExamRequest openExamRequest) throws ReturnStatusException;
-  
+
   /**
    * Fetches the approval status of the current exam
    *
@@ -39,7 +40,7 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Response<ExamApproval> getApproval(final UUID examId, final UUID sessionId, final UUID browserId) throws ReturnStatusException;
-  
+
   /**
    * Fetches the collection of approved {@link tds.exam.ExamAccommodation}s for an exam
    *
@@ -48,7 +49,7 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   List<ExamAccommodation> findApprovedAccommodations(final UUID examId) throws ReturnStatusException;
-  
+
   /**
    * Creates a request for the exam service to approve {@link tds.exam.ExamAccommodation}s
    *
@@ -57,7 +58,7 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   void approveAccommodations(final UUID examId, final ApproveAccommodationsRequest approveAccommodationsRequest) throws ReturnStatusException;
-  
+
   /**
    * Creates a request to update the status of an exam
    *
@@ -68,7 +69,7 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Optional<ValidationError> updateStatus(final UUID examId, final String status, final String reason) throws ReturnStatusException;
-  
+
   /**
    * Creates a request to start an exam
    *
@@ -77,4 +78,15 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Response<ExamConfiguration> startExam(final UUID examId) throws ReturnStatusException;
+
+  /**
+   * Creates a request to fetch {@link tds.exam.ExamSegment}s for an exam
+   *
+   * @param examId    the id of the exam
+   * @param sessionId the id of the session the exam is a part of
+   * @param browserId the id of the browser of the current session
+   * @return a {@link tds.common.Response} containing the list of {@link tds.exam.ExamSegment}s for the exam
+   * @throws ReturnStatusException
+   */
+  Response<List<ExamSegment>> findExamSegments(final UUID examId, final UUID sessionId, final UUID browserId) throws ReturnStatusException;
 }

--- a/student.library/src/main/java/tds/student/sql/abstractions/ExamRepository.java
+++ b/student.library/src/main/java/tds/student/sql/abstractions/ExamRepository.java
@@ -12,6 +12,7 @@ import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.ExamApproval;
+import tds.exam.ExamConfiguration;
 import tds.exam.OpenExamRequest;
 
 /**
@@ -67,4 +68,13 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Optional<ValidationError> updateStatus(final UUID examId, final String status, final String reason) throws ReturnStatusException;
+  
+  /**
+   * Creates a request to start an exam
+   *
+   * @param examId the id of the {@link tds.exam.Exam}
+   * @return the {@link tds.exam.ExamConfiguration} containing exam configuration metadata
+   * @throws ReturnStatusException
+   */
+  Response<ExamConfiguration> startExam(final UUID examId) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
@@ -247,13 +247,12 @@ public class RemoteOpportunityService implements IOpportunityService {
       return testConfig;
     }
   
-    
     /* Note that the formKeys argument can be ignored - it is an unused functionality */
     Response<ExamConfiguration> response = examRepository.startExam(oppInstance.getExamId());
 
     if (response.getError().isPresent()) {
-      ValidationError validationError = response.getError().get();
-      String errorMessage = validationError.getTranslatedMessage().isPresent()
+      final ValidationError validationError = response.getError().get();
+      final String errorMessage = validationError.getTranslatedMessage().isPresent()
         ? validationError.getTranslatedMessage().get()
         : validationError.getMessage();
 
@@ -264,11 +263,11 @@ public class RemoteOpportunityService implements IOpportunityService {
       throw new ReturnStatusException(String.format("Invalid response from the exam service when trying to start exam %s", oppInstance.getExamId()));
     }
 
-    ExamConfiguration examConfiguration = response.getData().get();
+    final ExamConfiguration examConfiguration = response.getData().get();
     
     /* OpportunityService - Conditional at line 288 */
     if (!examConfiguration.getStatus().equals(ExamStatusCode.STATUS_STARTED)) {
-      throw new ReturnStatusException("Failed to start the exam.");
+      throw new ReturnStatusException(String.format("Failed to start the exam."));
     }
 
     testConfig = mapExamConfigurationToTestConfig(examConfiguration);
@@ -292,15 +291,15 @@ public class RemoteOpportunityService implements IOpportunityService {
     Response<List<ExamSegment>> response = examRepository.findExamSegments(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
 
     if (response.getError().isPresent()) {
-      ValidationError validationError = response.getError().get();
-      String errorMessage = validationError.getTranslatedMessage().isPresent()
+      final ValidationError validationError = response.getError().get();
+      final String errorMessage = validationError.getTranslatedMessage().isPresent()
         ? validationError.getTranslatedMessage().get()
         : validationError.getMessage();
 
       throw new ReturnStatusException(errorMessage);
     }
 
-    List<ExamSegment> examSegments = response.getData().get();
+    final List<ExamSegment> examSegments = response.getData().get();
 
     opportunitySegments = mapExamSegmentsToOpportunitySegments(examSegments);
 

--- a/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
@@ -329,7 +329,7 @@ public class RemoteOpportunityService implements IOpportunityService {
     return testConfig;
   }
 
-  private OpportunitySegment.OpportunitySegments mapExamSegmentsToOpportunitySegments(List<ExamSegment> examSegments) {
+  private static OpportunitySegment.OpportunitySegments mapExamSegmentsToOpportunitySegments(List<ExamSegment> examSegments) {
     OpportunitySegment.OpportunitySegments opportunitySegments = new OpportunitySegment().new OpportunitySegments();
 
     for (ExamSegment examSegment : examSegments) {
@@ -340,7 +340,7 @@ public class RemoteOpportunityService implements IOpportunityService {
       oppSegment.setId(examSegment.getSegmentId());
       oppSegment.setKey(examSegment.getSegmentKey());
       oppSegment.setPosition(examSegment.getSegmentPosition());
-      oppSegment.setIsPermeable(examSegment.isPermeable() ? 1 : 0);
+      oppSegment.setIsPermeable(examSegment.isPermeable() ? 1 : -1);
       oppSegment.setRestorePermOn(examSegment.getRestorePermeableCondition());
       opportunitySegments.add(oppSegment);
     }

--- a/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
@@ -264,11 +264,6 @@ public class RemoteOpportunityService implements IOpportunityService {
     }
 
     final ExamConfiguration examConfiguration = response.getData().get();
-    
-    /* OpportunityService - Conditional at line 288 */
-    if (!examConfiguration.getStatus().equals(ExamStatusCode.STATUS_STARTED)) {
-      throw new ReturnStatusException(String.format("Failed to start the exam."));
-    }
 
     testConfig = mapExamConfigurationToTestConfig(examConfiguration);
 

--- a/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
@@ -246,7 +246,6 @@ public class RemoteExamRepository implements ExamRepository {
     return response;
   }
 
-
   @Override
   public Response<List<ExamSegment>> findExamSegments(UUID examId, UUID sessionId, UUID browserId) throws ReturnStatusException {
     HttpHeaders headers = new HttpHeaders();

--- a/student/src/test/java/tds/student/services/remote/RemoteAccommodationsServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteAccommodationsServiceTest.java
@@ -14,9 +14,9 @@ import java.util.UUID;
 
 import tds.accommodation.Accommodation;
 import tds.accommodation.AccommodationDependency;
-import tds.assessment.Algorithm;
 import tds.assessment.Assessment;
 import tds.assessment.Segment;
+import tds.common.Algorithm;
 import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.ExamAccommodation;
 import tds.student.services.abstractions.IAccommodationsService;

--- a/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
@@ -415,7 +415,7 @@ public class RemoteOpportunityServiceTest {
     assertThat(oppSeg1.getFormID()).isEqualTo(seg1.getFormId());
     assertThat(oppSeg1.getFormKey()).isEqualTo(seg1.getFormKey());
     assertThat(oppSeg1.getPosition()).isEqualTo(seg1.getSegmentPosition());
-    assertThat(oppSeg1.getIsPermeable()).isEqualTo(0);
+    assertThat(oppSeg1.getIsPermeable()).isEqualTo(-1);
     assertThat(oppSeg1.getRestorePermOn()).isEqualTo(seg1.getRestorePermeableCondition());
     assertThat(oppSeg1.getFtItems()).isEqualTo(String.valueOf(seg1.getFieldTestItemCount()));
 

--- a/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import tds.common.Response;
@@ -17,6 +19,7 @@ import tds.common.ValidationError;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
 import tds.exam.OpenExamRequest;
@@ -25,6 +28,7 @@ import tds.student.services.data.ApprovalInfo;
 import tds.student.sql.abstractions.ExamRepository;
 import tds.student.sql.data.OpportunityInfo;
 import tds.student.sql.data.OpportunityInstance;
+import tds.student.sql.data.OpportunitySegment;
 import tds.student.sql.data.OpportunityStatus;
 import tds.student.sql.data.OpportunityStatusChange;
 import tds.student.sql.data.OpportunityStatusExtensions;
@@ -135,101 +139,101 @@ public class RemoteOpportunityServiceTest {
   public void shouldThrowIfBothImplementationsAreDisabled() {
     new RemoteOpportunityService(legacyOpportunityService, false, false, examRepository);
   }
-  
+
   @Test
   public void shouldGetApprovedStatusNoErrors() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), null);
-      
+
     when(examRepository.getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey())).thenReturn(
       new Response(examApproval));
     OpportunityStatus retStatus = service.getStatus(oppInstance);
     assertThat(retStatus.getStatus().toString()).isEqualTo("Approved");
     verify(examRepository).getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
   }
-  
+
   @Test
   public void shouldGetDeniedStatusNoErrors() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_DENIED, ExamStatusStage.OPEN), null);
-    
+
     when(examRepository.getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey())).thenReturn(
       new Response(examApproval));
     OpportunityStatus retStatus = service.getStatus(oppInstance);
     assertThat(retStatus.getStatus().toString()).isEqualTo("Denied");
     verify(examRepository).getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
   }
-  
+
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowWithErrorsPresent() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_DENIED, ExamStatusStage.OPEN), null);
-    
+
     when(examRepository.getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey())).thenReturn(
       new Response(examApproval, new ValidationError("Some Error", "ErrorCode")));
     OpportunityStatus retStatus = service.getStatus(oppInstance);
   }
-  
+
   @Test
   public void shouldReturnApprovalInfo() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), null);
-  
+
     when(examRepository.getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey())).thenReturn(
       new Response(examApproval));
     ApprovalInfo approvalInfo = service.checkTestApproval(oppInstance);
     assertThat(approvalInfo.getStatus().toString()).isEqualTo("Approved");
     verify(examRepository).getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
   }
-  
+
   @Test
   public void shouldDenyApproval() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
-    
+
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
-  
+
     //mock getStatus
     when(examRepository.getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey()))
       .thenReturn(new Response<>(new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED), "reason")));
-  
+
     final String deniedStatus = ExamStatusCode.STATUS_DENIED;
     OpportunityStatusChange statusChange = new OpportunityStatusChange(OpportunityStatusType.Pending, true, deniedStatus);
     when(examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus)).thenReturn(Optional.<ValidationError>absent());
     service.denyApproval(oppInstance);
-    
+
     verify(examRepository).getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
     verify(examRepository).updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus);
   }
-  
+
   @Test
   public void shouldNotSetStatusIfStatusIsPaused() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Paused);
-  
+
     //mock getStatus
     when(examRepository.getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey()))
       .thenReturn(new Response<>(new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_PAUSED), "reason")));
-    
+
     service.denyApproval(oppInstance);
-  
+
     verify(examRepository).getApproval(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
     verify(examRepository, never()).updateStatus((UUID) any(), (String) any(), (String) any());
   }
-  
+
   @Test
   public void shouldUpdateStatus() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
-    
+
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Approved);
-    
+
     final String deniedStatus = ExamStatusCode.STATUS_DENIED;
     OpportunityStatusChange statusChange = new OpportunityStatusChange(OpportunityStatusType.Pending, true, deniedStatus);
     when(examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus)).thenReturn(Optional.<ValidationError>absent());
@@ -237,15 +241,15 @@ public class RemoteOpportunityServiceTest {
     assertThat(isApproved).isTrue();
     verify(examRepository).updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus);
   }
-  
+
   @Test
   public void shouldReturnTrueForErrorWithFalseCheckStatus() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
-    
+
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Approved);
-    
+
     final String deniedStatus = ExamStatusCode.STATUS_DENIED;
     OpportunityStatusChange statusChange = new OpportunityStatusChange(OpportunityStatusType.Pending, false, deniedStatus);
     when(examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus))
@@ -254,30 +258,30 @@ public class RemoteOpportunityServiceTest {
     assertThat(isApproved).isTrue();
     verify(examRepository).updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus);
   }
-  
+
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForReturnStatusFailed() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
-    
+
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Approved);
-    
+
     final String deniedStatus = ExamStatusCode.STATUS_DENIED;
     OpportunityStatusChange statusChange = new OpportunityStatusChange(OpportunityStatusType.Pending, true, deniedStatus);
     when(examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus))
       .thenReturn(Optional.of(new ValidationError(ExamStatusCode.STATUS_FAILED, "There was an error!")));
     service.setStatus(oppInstance, statusChange);
   }
-  
+
   @Test
   public void shouldReturnFalseForValidationErrorReturned() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
-  
+
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Approved);
-  
+
     final String deniedStatus = ExamStatusCode.STATUS_DENIED;
     OpportunityStatusChange statusChange = new OpportunityStatusChange(OpportunityStatusType.Pending, true, deniedStatus);
     when(examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus))
@@ -286,24 +290,24 @@ public class RemoteOpportunityServiceTest {
     assertThat(isApproved).isFalse();
     verify(examRepository).updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), deniedStatus);
   }
-  
+
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForErrorPresent() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
     Response<ExamConfiguration> errorResponse = new Response<>(new ValidationError("uh", "oh!"));
-  
+
     when(examRepository.startExam(oppInstance.getExamId())).thenReturn(errorResponse);
     service.startTest(oppInstance, assessmentKey, null);
   }
-  
+
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForReturnStatusNotStarted() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
-  
+
     ExamConfiguration mockExamConfig = new ExamConfiguration.Builder()
       .withExam(
         new Exam.Builder()
@@ -320,17 +324,17 @@ public class RemoteOpportunityServiceTest {
       .withStartPosition(1)
       .withExamRestartWindowMinutes(60)
       .build();
-  
+
     when(examRepository.startExam(oppInstance.getExamId())).thenReturn(new Response<>(mockExamConfig));
     service.startTest(oppInstance, assessmentKey, null);
   }
-  
+
   @Test
   public void shouldStartExamAndReturnTestConfig() throws ReturnStatusException {
     service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
-  
+
     ExamConfiguration mockExamConfig = new ExamConfiguration.Builder()
       .withExam(
         new Exam.Builder()
@@ -347,11 +351,11 @@ public class RemoteOpportunityServiceTest {
       .withStartPosition(1)
       .withExamRestartWindowMinutes(60)
       .build();
-  
+
     when(examRepository.startExam(oppInstance.getExamId())).thenReturn(new Response<>(mockExamConfig));
     TestConfig testConfig = service.startTest(oppInstance, assessmentKey, null);
     verify(examRepository).startExam(oppInstance.getExamId());
-    
+
     assertThat(testConfig).isNotNull();
     assertThat(testConfig.getStatus()).isEqualTo(OpportunityStatusExtensions.parseExamStatus(ExamStatusCode.STATUS_STARTED));
     assertThat(testConfig.getPrefetch()).isEqualTo(mockExamConfig.getPrefetch());
@@ -361,6 +365,76 @@ public class RemoteOpportunityServiceTest {
     assertThat(testConfig.getRequestInterfaceTimeout()).isEqualTo(mockExamConfig.getRequestInterfaceTimeoutMinutes());
     assertThat(testConfig.getRestart()).isEqualTo(mockExamConfig.getExam().getRestartsAndResumptions());
     assertThat(testConfig.getStartPosition()).isEqualTo(mockExamConfig.getStartPosition());
+  }
+
+  @Test
+  public void shouldFindExamSegmentsForExamIds() throws ReturnStatusException {
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    ExamSegment seg1 = new ExamSegment.Builder()
+      .withSegmentKey("seg1")
+      .withSegmentId("seg1ID")
+      .withFormKey("seg1formkey")
+      .withFormId("seg1formid")
+      .withPermeable(false)
+      .withExamId(oppInstance.getExamId())
+      .withSegmentPosition(1)
+      .withRestorePermeableCondition("Neva!")
+      .withFieldTestItemCount(0)
+      .build();
+    ExamSegment seg2 = new ExamSegment.Builder()
+      .withSegmentKey("seg2")
+      .withSegmentId("seg2ID")
+      .withFormKey("seg2formkey")
+      .withFormId("seg2formid")
+      .withExamId(oppInstance.getExamId())
+      .withSegmentPosition(2)
+      .withRestorePermeableCondition("Neva!")
+      .withPermeable(true)
+      .withFieldTestItemCount(4)
+      .build();
+
+    when(examRepository.findExamSegments(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey()))
+      .thenReturn(new Response<>(Arrays.asList(seg1, seg2)));
+    OpportunitySegment.OpportunitySegments opportunitySegments = service.getSegments(oppInstance, true);
+    verify(examRepository).findExamSegments(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey());
+
+    assertThat(opportunitySegments).isNotNull();
+    OpportunitySegment oppSeg1 = null;
+    OpportunitySegment oppSeg2 = null;
+
+    for (OpportunitySegment oppSeg : opportunitySegments) {
+      if (oppSeg.getKey().equals(seg1.getSegmentKey())) {
+        oppSeg1 = oppSeg;
+      } else if (oppSeg.getKey().equals((seg2.getSegmentKey()))) {
+        oppSeg2 = oppSeg;
+      }
+    }
+
+    assertThat(oppSeg1.getId()).isEqualTo(seg1.getSegmentId());
+    assertThat(oppSeg1.getFormID()).isEqualTo(seg1.getFormId());
+    assertThat(oppSeg1.getFormKey()).isEqualTo(seg1.getFormKey());
+    assertThat(oppSeg1.getPosition()).isEqualTo(seg1.getSegmentPosition());
+    assertThat(oppSeg1.getIsPermeable()).isEqualTo(0);
+    assertThat(oppSeg1.getRestorePermOn()).isEqualTo(seg1.getRestorePermeableCondition());
+    assertThat(oppSeg1.getFtItems()).isEqualTo(String.valueOf(seg1.getFieldTestItemCount()));
+
+    assertThat(oppSeg2.getId()).isEqualTo(seg2.getSegmentId());
+    assertThat(oppSeg2.getFormID()).isEqualTo(seg2.getFormId());
+    assertThat(oppSeg2.getFormKey()).isEqualTo(seg2.getFormKey());
+    assertThat(oppSeg2.getPosition()).isEqualTo(seg2.getSegmentPosition());
+    assertThat(oppSeg2.getIsPermeable()).isEqualTo(1);
+    assertThat(oppSeg2.getRestorePermOn()).isEqualTo(seg2.getRestorePermeableCondition());
+    assertThat(oppSeg2.getFtItems()).isEqualTo(String.valueOf(seg2.getFieldTestItemCount()));
+  }
+
+  @Test(expected = ReturnStatusException.class)
+  public void shouldThrowForErrorsPresentFindExamSegments() throws ReturnStatusException {
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    when(examRepository.findExamSegments(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey()))
+      .thenReturn(new Response<List<ExamSegment>>(new ValidationError("why", "not")));
+    service.getSegments(oppInstance, true);
   }
 }
 

--- a/student/src/test/java/tds/student/sql/repository/RemoteExamRepositoryTest.java
+++ b/student/src/test/java/tds/student/sql/repository/RemoteExamRepositoryTest.java
@@ -160,11 +160,6 @@ public class RemoteExamRepositoryTest {
   @Test
   public void shouldReturnResponseWithValidationErrorsForClientException() throws ReturnStatusException {
     UUID examId = UUID.randomUUID();
-    Response<ExamConfiguration> mockResponse = new Response<>(
-      new ExamConfiguration.Builder()
-        .withStatus("test")
-        .build());
-  
     when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
       .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Invalid", ERROR_JSON.getBytes(), null));
   


### PR DESCRIPTION
Integration of start exam endpoint to legacy student. This code corresponds to OpportunityService.startTest(). Primary entrypoint is RemoteOpportunityService.startTest(), which is called by the MasterShellHandler.java