### PR TITLE
Feature/exam opportunity id mapping

### DIFF
--- a/student/src/main/java/tds/student/performance/dao/TestOpportunityExamMapDao.java
+++ b/student/src/main/java/tds/student/performance/dao/TestOpportunityExamMapDao.java
@@ -3,5 +3,5 @@ package tds.student.performance.dao;
 import java.util.UUID;
 
 public interface TestOpportunityExamMapDao {
-    void insert(UUID testOpportunityId, UUID examId);
+    void insert(final UUID testOpportunityId, final UUID examId);
 }

--- a/student/src/main/java/tds/student/performance/dao/TestOpportunityExamMapDao.java
+++ b/student/src/main/java/tds/student/performance/dao/TestOpportunityExamMapDao.java
@@ -1,0 +1,7 @@
+package tds.student.performance.dao;
+
+import java.util.UUID;
+
+public interface TestOpportunityExamMapDao {
+    void insert(UUID testOpportunityId, UUID examId);
+}

--- a/student/src/main/java/tds/student/performance/dao/TestOpportunityExamMapDao.java
+++ b/student/src/main/java/tds/student/performance/dao/TestOpportunityExamMapDao.java
@@ -2,6 +2,16 @@ package tds.student.performance.dao;
 
 import java.util.UUID;
 
+/**
+ * Used to store mapping from legacy test opportunity IDs to the new exam IDs.  This is used when in the mode of calling
+ * both the legacy services as well as the new services.  Eventually this will be removed.
+ */
 public interface TestOpportunityExamMapDao {
+
+    /**
+     * Insert a record mapping the test opportunity ID and exam ID
+     * @param testOpportunityId test opportunity ID from session.testopportunity table
+     * @param examId exam ID used in the new exam.exam table
+     */
     void insert(final UUID testOpportunityId, final UUID examId);
 }

--- a/student/src/main/java/tds/student/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
+++ b/student/src/main/java/tds/student/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
@@ -1,0 +1,47 @@
+package tds.student.performance.dao.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import tds.dll.common.performance.utils.LegacyDbNameUtility;
+import tds.student.performance.dao.TestOpportunityExamMapDao;
+
+@Repository
+public class TestOpportunityExamMapDaoImpl implements TestOpportunityExamMapDao {
+    private static final Logger logger = LoggerFactory.getLogger(TestOpportunityExamMapDaoImpl.class);
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Autowired
+    private LegacyDbNameUtility dbNameUtility;
+
+    @Autowired
+    public void setDataSource(DataSource dataSource) {
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    @Override
+    public void insert(UUID testOpportunityId, UUID examId) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("testopportunityId", testOpportunityId.toString());
+        parameters.put("examId", examId.toString());
+
+        final String sql = "INSERT INTO ${sessiondb}.testopportunity_exam_map (testopportunity_id, exam_id) " +
+            "VALUES (:testopportunityId, :examId)";
+
+        try {
+            namedParameterJdbcTemplate.update(dbNameUtility.setDatabaseNames(sql), parameters);
+        } catch (DataAccessException e) {
+            logger.error(String.format("%s UPDATE threw exception", sql), e);
+            throw e;
+        }
+    }
+}

--- a/student/src/main/java/tds/student/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
+++ b/student/src/main/java/tds/student/performance/dao/impl/TestOpportunityExamMapDaoImpl.java
@@ -29,7 +29,7 @@ public class TestOpportunityExamMapDaoImpl implements TestOpportunityExamMapDao 
     }
 
     @Override
-    public void insert(UUID testOpportunityId, UUID examId) {
+    public void insert(final UUID testOpportunityId, final UUID examId) {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("testopportunityId", testOpportunityId.toString());
         parameters.put("examId", examId.toString());

--- a/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
@@ -52,11 +52,11 @@ public class RemoteOpportunityService implements IOpportunityService {
 
   @Autowired
   public RemoteOpportunityService(
-    @Qualifier("legacyOpportunityService") IOpportunityService legacyOpportunityService,
-    @Value("${tds.exam.remote.enabled}") Boolean remoteExamCallsEnabled,
-    @Value("${tds.exam.legacy.enabled}") Boolean legacyCallsEnabled,
-    ExamRepository examRepository,
-    TestOpportunityExamMapDao testOpportunityExamMapDao) {
+    @Qualifier("legacyOpportunityService") final IOpportunityService legacyOpportunityService,
+    @Value("${tds.exam.remote.enabled}") final Boolean remoteExamCallsEnabled,
+    @Value("${tds.exam.legacy.enabled}") final Boolean legacyCallsEnabled,
+    final ExamRepository examRepository,
+    final TestOpportunityExamMapDao testOpportunityExamMapDao) {
 
     if (!remoteExamCallsEnabled && !legacyCallsEnabled) {
       throw new IllegalStateException("Remote and legacy calls are both disabled.  Please check progman configuration");

--- a/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
@@ -23,6 +23,7 @@ import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
 import tds.exam.OpenExamRequest;
+import tds.student.performance.dao.TestOpportunityExamMapDao;
 import tds.student.services.abstractions.IOpportunityService;
 import tds.student.services.data.ApprovalInfo;
 import tds.student.sql.abstractions.ExamRepository;
@@ -55,9 +56,12 @@ public class RemoteOpportunityServiceTest {
   @Mock
   private ExamRepository examRepository;
 
+  @Mock
+  private TestOpportunityExamMapDao testOpportunityExamMapDao;
+
   @Before
   public void setUp() {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, true, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, true, examRepository, testOpportunityExamMapDao);
   }
 
   @After
@@ -106,7 +110,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldNotExecuteRemoteCallIfNotEnabled() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, false, true, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, false, true, examRepository, testOpportunityExamMapDao);
 
     Testee testee = new Testee();
     TestSession testSession = new TestSession();
@@ -125,7 +129,7 @@ public class RemoteOpportunityServiceTest {
 
     when(examRepository.openExam(isA(OpenExamRequest.class))).thenReturn(response);
 
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
 
     Testee testee = new Testee();
     TestSession testSession = new TestSession();
@@ -137,12 +141,12 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = IllegalStateException.class)
   public void shouldThrowIfBothImplementationsAreDisabled() {
-    new RemoteOpportunityService(legacyOpportunityService, false, false, examRepository);
+    new RemoteOpportunityService(legacyOpportunityService, false, false, examRepository, testOpportunityExamMapDao);
   }
 
   @Test
   public void shouldGetApprovedStatusNoErrors() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), null);
 
@@ -155,7 +159,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldGetDeniedStatusNoErrors() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_DENIED, ExamStatusStage.OPEN), null);
 
@@ -168,7 +172,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowWithErrorsPresent() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_DENIED, ExamStatusStage.OPEN), null);
 
@@ -179,7 +183,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldReturnApprovalInfo() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), null);
 
@@ -192,7 +196,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldDenyApproval() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
 
@@ -211,7 +215,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldNotSetStatusIfStatusIsPaused() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Paused);
@@ -228,7 +232,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldUpdateStatus() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -244,7 +248,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldReturnTrueForErrorWithFalseCheckStatus() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -261,7 +265,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForReturnStatusFailed() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -276,7 +280,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldReturnFalseForValidationErrorReturned() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -293,7 +297,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForErrorPresent() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
     Response<ExamConfiguration> errorResponse = new Response<>(new ValidationError("uh", "oh!"));
@@ -304,7 +308,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldStartExamAndReturnTestConfig() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
 
@@ -342,7 +346,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldFindExamSegmentsForExamIds() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamSegment seg1 = new ExamSegment.Builder()
       .withSegmentKey("seg1")
@@ -403,7 +407,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForErrorsPresentFindExamSegments() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     when(examRepository.findExamSegments(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey()))
       .thenReturn(new Response<List<ExamSegment>>(new ValidationError("why", "not")));


### PR DESCRIPTION
Inserts a new record that maps examId to legacy testOpportunityId on openExam.  This data is then fetched on the Proctor side when the proctor UI calls the API with the new exam ids.  In order to also call the legacy services that exam id needs to be translated to the test opportunity id.

This is using the legacy performance way of doing things since it interacts with the legacy DB.  I created DAO and put it in the performance package.

I've implemented for approve, deny and approve accommodations on Proctor at this point.

NOTE: I'd like to discuss the best way to get the new table created.  I manually create in dev at this point and there isn't a migration path for the legacy tables that I'm aware of.

```
CREATE TABLE testopportunity_exam_map (
  testopportunity_id char(36) NOT NULL,
  exam_id char(36) NOT NULL,
  PRIMARY KEY (testopportunity_id,exam_id)
)
```