### PR TITLE
Bugfix - marking all approved accommodations as “selected”

### DIFF
--- a/student/src/main/java/tds/student/services/remote/RemoteAccommodationsService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteAccommodationsService.java
@@ -145,7 +145,7 @@ public class RemoteAccommodationsService implements IAccommodationsService {
           // Create accommodations type and value - these will be used by the UI between checkApproval and startTest
           retAccommodations.create(accommodation.getType(), accommodation.getCode(), accommodation.getValue(), accommodation.isVisible(),
             accommodation.isSelectable(), accommodation.isAllowChange(), accommodation.isStudentControl(), accommodation.getDependsOnToolType(),
-            accommodation.isDisableOnGuestSession(), accommodation.isDefaultAccommodation(), accommodation.isAllowCombine(), accommodation.isSelectable());
+            accommodation.isDisableOnGuestSession(), accommodation.isDefaultAccommodation(), accommodation.isAllowCombine(), true);
         }
       }
     }


### PR DESCRIPTION
Previously, on the student side, accommodation values that were "selected" and approved were being set to the accommodations "isSelectable" boolean value. This was causing many accommodations that are not selectable but should be enabled by default to be marked as non-selected, contributing to errors seen in TDS-725.