### PR TITLE
Print/emboss integration

### DIFF
--- a/student.library/src/main/java/tds/student/services/abstractions/PrintService.java
+++ b/student.library/src/main/java/tds/student/services/abstractions/PrintService.java
@@ -1,0 +1,102 @@
+package tds.student.services.abstractions;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+
+import tds.itemrenderer.data.AccLookup;
+import tds.student.services.data.ItemResponse;
+import tds.student.services.data.PageGroup;
+import tds.student.services.data.TestOpportunity;
+import tds.student.sql.data.OpportunityInstance;
+
+/**
+ * A service for creating print requests
+ */
+public interface PrintService {
+  /**
+   * Creates a print request to print a passage
+   *
+   * @param oppInstance       The opportunity instance containing exam information
+   * @param pageGroupToPrint  The page group to print
+   * @param requestParameters Additional request parameters for the print request
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printPassage(OpportunityInstance oppInstance, PageGroup pageGroupToPrint, String requestParameters) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to print a page
+   *
+   * @param oppInstance       The opportunity instance containing exam information
+   * @param pageGroupToPrint  The page group to print
+   * @param requestParameters Additional request parameters for the print request
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printPage(OpportunityInstance oppInstance, PageGroup pageGroupToPrint, String requestParameters) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to print a passage or page
+   *
+   * @param oppInstance       The opportunity instance containing exam information
+   * @param pageGroupToPrint  The page group to print
+   * @param requestParameters Additional request parameters for the print request
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printPassage(String requestType, OpportunityInstance oppInstance, PageGroup pageGroupToPrint, String requestParameters) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to print an item
+   *
+   * @param oppInstance       The opportunity instance containing exam information
+   * @param responseToPrint   The item to print
+   * @param requestParameters Additional request parameters for the print request
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printItem(OpportunityInstance oppInstance, ItemResponse responseToPrint, String requestParameters) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to emboss a passage
+   *
+   * @param testOpp          The test opportunity object containing exam information
+   * @param pageGroupToPrint The page group to emboss
+   * @param accLookup        The map of exam accommodations
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printPassageBraille(TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to emboss a page
+   *
+   * @param testOpp          The test opportunity object containing exam information
+   * @param pageGroupToPrint The page group to emboss
+   * @param accLookup        The map of exam accommodations
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printPageBraille(TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to emboss a page or passage
+   *
+   * @param testOpp          The test opportunity object containing exam information
+   * @param pageGroupToPrint The page group to emboss
+   * @param accLookup        The map of exam accommodations
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printPassageBraille(String requestType, TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException;
+
+  /**
+   * Creates a print request to emboss an item
+   *
+   * @param testOpp         The test opportunity object containing exam information
+   * @param responseToPrint The item to emboss
+   * @param accLookup       The map of exam accommodations
+   * @return True if successful, false otherwise
+   * @throws ReturnStatusException
+   */
+  boolean printItemBraille(TestOpportunity testOpp, ItemResponse responseToPrint, AccLookup accLookup) throws ReturnStatusException;
+}

--- a/student.library/src/main/java/tds/student/services/abstractions/PrintService.java
+++ b/student.library/src/main/java/tds/student/services/abstractions/PrintService.java
@@ -18,8 +18,8 @@ public interface PrintService {
    * @param oppInstance       The opportunity instance containing exam information
    * @param pageGroupToPrint  The page group to print
    * @param requestParameters Additional request parameters for the print request
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
+   * @return {@code true} if successful, {@code false} otherwise
+   * @throws ReturnStatusException thrown if xml path for resource is null or empty
    */
   boolean printPassage(OpportunityInstance oppInstance, PageGroup pageGroupToPrint, String requestParameters) throws ReturnStatusException;
 
@@ -29,21 +29,10 @@ public interface PrintService {
    * @param oppInstance       The opportunity instance containing exam information
    * @param pageGroupToPrint  The page group to print
    * @param requestParameters Additional request parameters for the print request
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
+   * @return {@code true} if successful, {@code false} otherwise
+   * @throws ReturnStatusException thrown if xml path for resource is null or empty
    */
   boolean printPage(OpportunityInstance oppInstance, PageGroup pageGroupToPrint, String requestParameters) throws ReturnStatusException;
-
-  /**
-   * Creates a print request to print a passage or page
-   *
-   * @param oppInstance       The opportunity instance containing exam information
-   * @param pageGroupToPrint  The page group to print
-   * @param requestParameters Additional request parameters for the print request
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
-   */
-  boolean printPassage(String requestType, OpportunityInstance oppInstance, PageGroup pageGroupToPrint, String requestParameters) throws ReturnStatusException;
 
   /**
    * Creates a print request to print an item
@@ -51,8 +40,8 @@ public interface PrintService {
    * @param oppInstance       The opportunity instance containing exam information
    * @param responseToPrint   The item to print
    * @param requestParameters Additional request parameters for the print request
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
+   * @return {@code true} if successful, {@code false} otherwise
+   * @throws ReturnStatusException thrown if xml path for resource is null or empty
    */
   boolean printItem(OpportunityInstance oppInstance, ItemResponse responseToPrint, String requestParameters) throws ReturnStatusException;
 
@@ -62,8 +51,8 @@ public interface PrintService {
    * @param testOpp          The test opportunity object containing exam information
    * @param pageGroupToPrint The page group to emboss
    * @param accLookup        The map of exam accommodations
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
+   * @return {@code true} if successful, {@code false} otherwise
+   * @throws ReturnStatusException thrown if xml path for resource is null or empty
    */
   boolean printPassageBraille(TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException;
 
@@ -73,21 +62,10 @@ public interface PrintService {
    * @param testOpp          The test opportunity object containing exam information
    * @param pageGroupToPrint The page group to emboss
    * @param accLookup        The map of exam accommodations
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
+   * @return {@code true} if successful, {@code false} otherwise
+   * @throws ReturnStatusException thrown if xml path for resource is null or empty
    */
   boolean printPageBraille(TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException;
-
-  /**
-   * Creates a print request to emboss a page or passage
-   *
-   * @param testOpp          The test opportunity object containing exam information
-   * @param pageGroupToPrint The page group to emboss
-   * @param accLookup        The map of exam accommodations
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
-   */
-  boolean printPassageBraille(String requestType, TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException;
 
   /**
    * Creates a print request to emboss an item
@@ -95,8 +73,8 @@ public interface PrintService {
    * @param testOpp         The test opportunity object containing exam information
    * @param responseToPrint The item to emboss
    * @param accLookup       The map of exam accommodations
-   * @return True if successful, false otherwise
-   * @throws ReturnStatusException
+   * @return {@code true} if successful, {@code false} otherwise
+   * @throws ReturnStatusException thrown if xml path for resource is null or empty
    */
   boolean printItemBraille(TestOpportunity testOpp, ItemResponse responseToPrint, AccLookup accLookup) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/services/PrintService.java
+++ b/student/src/main/java/tds/student/services/PrintService.java
@@ -178,10 +178,10 @@ public class PrintService
       String xmlPath = pageGroupToPrint.getFilePath ();
       if (StringUtils.isEmpty (xmlPath)) {
         throw new ReturnStatusException (
-            new Exception (
-                String.format (
-                    "PrintPassageBraille: Invalid xml file path for group %1$s.",
-                    pageGroupToPrint.getId ())));
+          new Exception (
+            String.format (
+              "PrintPassageBraille: Invalid xml file path for group %1$s.",
+              pageGroupToPrint.getId ())));
       }
 
       // try and load document if it isn't already loaded

--- a/student/src/main/java/tds/student/services/PrintServiceImpl.java
+++ b/student/src/main/java/tds/student/services/PrintServiceImpl.java
@@ -180,10 +180,9 @@ public class PrintServiceImpl implements PrintService
       String xmlPath = pageGroupToPrint.getFilePath ();
       if (StringUtils.isEmpty (xmlPath)) {
         throw new ReturnStatusException (
-          new Exception (
             String.format (
               "PrintPassageBraille: Invalid xml file path for group %1$s.",
-              pageGroupToPrint.getId ())));
+              pageGroupToPrint.getId ()));
       }
 
       // try and load document if it isn't already loaded
@@ -255,10 +254,9 @@ public class PrintServiceImpl implements PrintService
       String xmlPath = responseToPrint.getFilePath ();
       if (StringUtils.isEmpty (xmlPath)) {
         throw new ReturnStatusException (
-            new Exception (
                 String.format (
                     "PrintItemBraille: Invalid xml file path for item %1$s",
-                    responseToPrint.getItemID ())));
+                    responseToPrint.getItemID ()));
       }
       // try and load document if it isn't already loaded
       if (responseToPrint.getDocument () == null) {

--- a/student/src/main/java/tds/student/services/PrintServiceImpl.java
+++ b/student/src/main/java/tds/student/services/PrintServiceImpl.java
@@ -8,27 +8,28 @@
  ******************************************************************************/
 package tds.student.services;
 
+import AIR.Common.TDSLogger.ITDSLogger;
+import TDS.Shared.Exceptions.ReturnStatusException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import tds.itemrenderer.data.AccLookup;
 import tds.itemrenderer.data.ITSAttachment;
 import tds.itemrenderer.data.ITSContent;
 import tds.student.services.abstractions.IContentService;
+import tds.student.services.abstractions.PrintService;
 import tds.student.services.data.ItemResponse;
 import tds.student.services.data.PageGroup;
 import tds.student.services.data.TestOpportunity;
 import tds.student.sql.abstractions.IOpportunityRepository;
 import tds.student.sql.data.OpportunityInstance;
-import AIR.Common.TDSLogger.ITDSLogger;
-import TDS.Shared.Exceptions.ReturnStatusException;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * @author temp_rreddy
@@ -36,10 +37,11 @@ import java.util.List;
  */
 @Component
 @Scope ("prototype")
-public class PrintService
+@Service("legacyPrintService")
+public class PrintServiceImpl implements PrintService
 {
   private static final Logger    _logger = LoggerFactory
-                                             .getLogger (PrintService.class);
+                                             .getLogger (PrintServiceImpl.class);
 
   @Autowired
   IContentService                _contentService;

--- a/student/src/main/java/tds/student/services/remote/RemotePrintService.java
+++ b/student/src/main/java/tds/student/services/remote/RemotePrintService.java
@@ -1,0 +1,354 @@
+package tds.student.services.remote;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+import tds.itemrenderer.data.AccLookup;
+import tds.itemrenderer.data.IITSDocument;
+import tds.itemrenderer.data.ITSAttachment;
+import tds.itemrenderer.data.ITSContent;
+import tds.student.services.PrintService;
+import tds.student.services.abstractions.IContentService;
+import tds.student.services.data.ItemResponse;
+import tds.student.services.data.PageGroup;
+import tds.student.services.data.TestOpportunity;
+import tds.student.sql.data.OpportunityInstance;
+import tds.student.sql.repository.ExamRepository;
+
+@Service("integrationPrintService")
+@Scope("prototype")
+public class RemotePrintService extends PrintService {
+  private static final Logger LOG = LoggerFactory.getLogger(RemotePrintService.class);
+  private static final int PASSAGE_PRINT_ITEM_POSITION_DEFAULT = 0;
+
+  private final boolean isRemoteExamCallsEnabled;
+  private final boolean isLegacyCallsEnabled;
+  private final ExamRepository examRepository;
+  private final IContentService contentService;
+
+  @Autowired
+  public RemotePrintService(
+    @Value("${tds.exam.remote.enabled}") final Boolean remoteExamCallsEnabled,
+    @Value("${tds.exam.legacy.enabled}") final Boolean legacyCallsEnabled,
+    final ExamRepository examRepository,
+    final IContentService contentService) {
+
+    if (!remoteExamCallsEnabled && !legacyCallsEnabled) {
+      throw new IllegalStateException("Remote and legacy calls are both disabled.  Please check progman configuration");
+    }
+
+    this.isRemoteExamCallsEnabled = remoteExamCallsEnabled;
+    this.isLegacyCallsEnabled = legacyCallsEnabled;
+    this.examRepository = examRepository;
+    this.contentService = contentService;
+  }
+
+  @Override
+  public boolean printPassage(final OpportunityInstance oppInstance, final PageGroup pageGroupToPrint, final String requestParameters) throws ReturnStatusException {
+    return printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, oppInstance, pageGroupToPrint, requestParameters);
+  }
+
+  @Override
+  public boolean printPage(final OpportunityInstance oppInstance, final PageGroup pageGroupToPrint, final String requestParameters) throws ReturnStatusException {
+    return printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PAGE, oppInstance, pageGroupToPrint, requestParameters);
+  }
+
+  /* PrintService - printPassage() - line 117 */
+  @Override
+  public boolean printPassage(final String requestType, final OpportunityInstance oppInstance, final PageGroup pageGroupToPrint, final String requestParameters) throws ReturnStatusException {
+    boolean isSuccessful = false;
+
+    if (isLegacyCallsEnabled) {
+      isSuccessful = super.printPassage(requestType, oppInstance, pageGroupToPrint, requestParameters);
+    }
+
+    //This isn't ideal, but due to the way the progman properties are loaded within the system this lives within the service rather than the callers.
+    if (!isRemoteExamCallsEnabled) {
+      return isSuccessful;
+    }
+
+    if (pageGroupToPrint == null || pageGroupToPrint.size() == 0) {
+      return false;
+    }
+
+    final String requestValue = pageGroupToPrint.getFilePath();
+
+    if (StringUtils.isEmpty(requestValue)) {
+      return false;
+    }
+
+    final ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+      .withExamId(oppInstance.getExamId())
+      .withSessionId(oppInstance.getSessionKey())
+      .withPagePosition(pageGroupToPrint.getNumber())
+      .withItemPosition(PASSAGE_PRINT_ITEM_POSITION_DEFAULT)
+      .withType(requestType)
+      .withDescription(getPassageLabel(pageGroupToPrint, false))
+      .withParameters(requestParameters)
+      .withValue(requestValue.replace("\\", "\\\\"))
+      .build();
+
+    examRepository.createPrintRequest(request);
+
+    return true;
+  }
+
+  @Override
+  public boolean printItem(final OpportunityInstance opportunityInstance, final ItemResponse responseToPrint, final String requestParameters) throws ReturnStatusException {
+    boolean isSuccessful = false;
+
+    if (isLegacyCallsEnabled) {
+      isSuccessful = super.printItem(opportunityInstance, responseToPrint, requestParameters);
+    }
+
+    //This isn't ideal, but due to the way the progman properties are loaded within the system this lives within the service rather than the callers.
+    if (!isRemoteExamCallsEnabled) {
+      return isSuccessful;
+    }
+
+    if (responseToPrint == null) {
+      return false;
+    }
+
+    final String requestValue = responseToPrint.getFilePath();
+
+    if (StringUtils.isEmpty(requestValue)) {
+      return false;
+    }
+
+    final ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+      .withExamId(opportunityInstance.getExamId())
+      .withSessionId(opportunityInstance.getSessionKey())
+      .withPagePosition(responseToPrint.getPage())
+      .withItemPosition(responseToPrint.getPosition()) // if this is page, this val is 0 - look into combinging print page/item
+      .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+      .withDescription(getItemLabel(responseToPrint, false))
+      .withParameters(requestParameters)
+      .withValue(requestValue.replace("\\", "\\\\"))
+      .build();
+
+    examRepository.createPrintRequest(request);
+
+    return true;
+  }
+
+  @Override
+  public boolean printPassageBraille(String requestType, TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException {
+    boolean isSuccessful = false;
+
+    if (isLegacyCallsEnabled) {
+      isSuccessful = super.printPassageBraille(requestType, testOpp, pageGroupToPrint, accLookup);
+    }
+
+    //This isn't ideal, but due to the way the progman properties are loaded within the system this lives within the service rather than the callers.
+    if (!isRemoteExamCallsEnabled) {
+      return isSuccessful;
+    }
+
+    if (pageGroupToPrint == null || pageGroupToPrint.size() == 0) {
+      return false;
+    }
+
+    String xmlPath = pageGroupToPrint.getFilePath();
+
+    if (StringUtils.isEmpty(xmlPath)) {
+      throw new ReturnStatusException(String.format("PrintPassageBraille: Invalid xml file path for group %1$s.", pageGroupToPrint.getId()));
+    }
+
+    IITSDocument document = pageGroupToPrint.getDocument();
+
+    // try and load document if it isn't already loaded
+    if (document == null) {
+      document = contentService.getContent(xmlPath, accLookup);
+
+      if (document == null) {
+        return false;
+      }
+
+      pageGroupToPrint.setDocument(document);
+    }
+
+    ITSContent content = document.getContent(testOpp.getLanguage());
+
+    if (content == null) {
+      return false;
+    }
+
+    // get attachments for the accommodations braille type
+    List<ITSAttachment> brailleAttachments = content.GetBrailleTypeAttachment(accLookup);
+
+    if (brailleAttachments.isEmpty()) { // no need for null check, this is initialized as an empty list
+      LOG.warn("PrintPassageBraille: Cannot find a matching braille attachment for the test {} and passage {}.",
+        testOpp.getTestKey(), pageGroupToPrint.getId());
+      return false;
+    }
+
+    ITSAttachment mainBrailleAttachment = brailleAttachments.get(0);
+    String requestValue = mainBrailleAttachment.getFile();
+    String requestParameters = "FileFormat:" + mainBrailleAttachment.getType().toUpperCase(); // name:value;name:value
+
+    boolean isTranscript = isTranscriptRequest(brailleAttachments);
+
+    if (isTranscript) {
+      requestValue += ";" + brailleAttachments.get(1).getFile();
+    }
+
+    String requestDescription = String.format("%1$s (%2$s)", getPassageLabel(pageGroupToPrint, isTranscript),
+      mainBrailleAttachment.getType());
+
+    OpportunityInstance opportunityInstance = testOpp.getOppInstance();
+
+    final ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+      .withExamId(opportunityInstance.getExamId())
+      .withSessionId(opportunityInstance.getSessionKey())
+      .withPagePosition(pageGroupToPrint.getNumber())
+      .withItemPosition(PASSAGE_PRINT_ITEM_POSITION_DEFAULT)
+      .withType(requestType)
+      .withDescription(requestDescription)
+      .withParameters(requestParameters)
+      .withValue(requestValue.replace("\\", "\\\\"))
+      .build();
+
+    examRepository.createPrintRequest(request);
+
+    isSuccessful = true;
+    pageGroupToPrint.setPrinted(isSuccessful);
+
+    return isSuccessful;
+  }
+
+  public boolean printItemBraille(TestOpportunity testOpp, ItemResponse responseToPrint, AccLookup accLookup) throws ReturnStatusException {
+    boolean isSuccessful = false;
+
+    if (isLegacyCallsEnabled) {
+      isSuccessful = super.printItemBraille(testOpp, responseToPrint, accLookup);
+    }
+
+    //This isn't ideal, but due to the way the progman properties are loaded within the system this lives within the service rather than the callers.
+    if (!isRemoteExamCallsEnabled) {
+      return isSuccessful;
+    }
+
+    String xmlPath = responseToPrint.getFilePath();
+
+    if (StringUtils.isEmpty(xmlPath)) {
+      throw new ReturnStatusException(String.format("PrintItemBraille: Invalid xml file path for item %1$s.", responseToPrint.getItemID()));
+    }
+
+    IITSDocument document = responseToPrint.getDocument();
+
+    // try and load document if it isn't already loaded
+    if (document == null) {
+      document = contentService.getContent(xmlPath, accLookup);
+
+      if (document == null) {
+        return false;
+      }
+
+      responseToPrint.setDocument(document);
+    }
+
+    ITSContent content = document.getContent(testOpp.getLanguage());
+
+    if (content == null) {
+      return false;
+    }
+
+    // get attachments for the accommodations braille type
+    List<ITSAttachment> brailleAttachments = content.GetBrailleTypeAttachment(accLookup);
+
+    if (brailleAttachments.isEmpty()) { // no need for null check, this is initialized as an empty list
+      LOG.warn("PrintItemBraille: Cannot find a matching braille attachment for the test {} and item {}.",
+        testOpp.getTestKey(), responseToPrint.getItemID());
+      return false;
+    }
+
+    ITSAttachment mainBrailleAttachment = brailleAttachments.get(0);
+    String requestValue = mainBrailleAttachment.getFile();
+    String requestParameters = "FileFormat:" + mainBrailleAttachment.getType().toUpperCase(); // name:value;name:value
+
+    boolean isTranscript = isTranscriptRequest(brailleAttachments);
+
+    if (isTranscript) {
+      requestValue += ";" + brailleAttachments.get(1).getFile();
+    }
+
+    String requestDescription = String.format("%1$s (%2$s)", getItemLabel(responseToPrint, isTranscript),
+      mainBrailleAttachment.getType());
+
+    OpportunityInstance opportunityInstance = testOpp.getOppInstance();
+
+    final ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+      .withExamId(opportunityInstance.getExamId())
+      .withSessionId(opportunityInstance.getSessionKey())
+      .withPagePosition(responseToPrint.getPage())
+      .withItemPosition(responseToPrint.getPosition())
+      .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
+      .withDescription(requestDescription)
+      .withParameters(requestParameters)
+      .withValue(requestValue.replace("\\", "\\\\"))
+      .build();
+
+    examRepository.createPrintRequest(request);
+
+    isSuccessful = true;
+    responseToPrint.setPrinted(isSuccessful);
+
+    return isSuccessful;
+  }
+
+  @Override
+  public boolean printPassageBraille(TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException {
+    return printPassageBraille("EMBOSSPASSAGE", testOpp, pageGroupToPrint, accLookup);
+  }
+
+  @Override
+  public boolean printPageBraille(TestOpportunity testOpp, PageGroup pageGroupToPrint, AccLookup accLookup) throws ReturnStatusException {
+    return printPassageBraille("EMBOSSPAGE", testOpp, pageGroupToPrint, accLookup);
+  }
+
+  private String getPassageLabel(PageGroup group, boolean isTranscript) throws ReturnStatusException {
+    StringBuilder label = new StringBuilder("Passage");
+
+    if (isTranscript) {
+      label.append(" and Transcript");
+    }
+
+    if (group.size() > 0) {
+      label.append(" for ");
+
+      ItemResponse firstResponse = group.getFirst();
+      if (group.size() == 1) {
+        String postion = String.format("Item %1$d", firstResponse.getPosition());
+        label.append(postion);
+
+      } else {
+        ItemResponse lastResponse = group.getLast();
+        String postion = String.format("Items %1$d-%2$d", firstResponse.getPosition(), lastResponse.getPosition());
+        label.append(postion);
+      }
+    }
+    return label.toString();
+  }
+
+  private String getItemLabel(final ItemResponse response, final boolean isTranscript) {
+    return String.format("%1$s %2$d", isTranscript ? "Item and Transcript" : "Item", response.getPosition());
+  }
+
+  /*
+   * Determines if the list of attachments means that this is a Braille Transcript embossing request
+   */
+  private static boolean isTranscriptRequest(List<ITSAttachment> brailleAttachments) {
+    return brailleAttachments.size() == 2 && brailleAttachments.get(1).getSubType().endsWith("_transcript");
+  }
+}

--- a/student/src/main/java/tds/student/sql/repository/ExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/ExamRepository.java
@@ -91,5 +91,11 @@ public interface ExamRepository {
    */
   Response<List<ExamSegment>> findExamSegments(final UUID examId, final UUID sessionId, final UUID browserId) throws ReturnStatusException;
 
+  /**
+   * Creats an {@link tds.exam.ExamPrintRequest} to print or emboss an item, page, or passage
+   *
+   * @param examPrintRequest The {@link tds.exam.ExamPrintRequest} containing print data
+   * @throws ReturnStatusException
+   */
   void createPrintRequest(ExamPrintRequest examPrintRequest) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/sql/repository/ExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/ExamRepository.java
@@ -13,6 +13,7 @@ import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamPrintRequest;
 import tds.exam.ExamSegment;
 import tds.exam.OpenExamRequest;
 
@@ -89,4 +90,6 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Response<List<ExamSegment>> findExamSegments(final UUID examId, final UUID sessionId, final UUID browserId) throws ReturnStatusException;
+
+  void createPrintRequest(ExamPrintRequest examPrintRequest) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
@@ -32,6 +32,7 @@ import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamPrintRequest;
 import tds.exam.ExamSegment;
 import tds.exam.OpenExamRequest;
 
@@ -269,5 +270,26 @@ public class RemoteExamRepository implements ExamRepository {
     }
 
     return responseEntity.getBody();
+  }
+
+  @Override
+  public void createPrintRequest(ExamPrintRequest examPrintRequest) throws ReturnStatusException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<?> requestHttpEntity = new HttpEntity<>(examPrintRequest, headers);
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/print", examUrl));
+
+    try {
+      restTemplate.exchange(
+        builder.build().toUri(),
+        HttpMethod.POST,
+        requestHttpEntity,
+        new ParameterizedTypeReference<String>() {
+        });
+    } catch (RestClientException rce) {
+      throw new ReturnStatusException(rce);
+    }
   }
 }

--- a/student/src/main/java/tds/student/web/handlers/ContentHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/ContentHandler.java
@@ -33,6 +33,7 @@ import tds.itemrenderer.data.ItemRenderGroup;
 import tds.student.services.PrintServiceImpl;
 import tds.student.services.abstractions.IContentService;
 import tds.student.services.abstractions.IResponseService;
+import tds.student.services.abstractions.PrintService;
 import tds.student.services.data.ItemResponse;
 import tds.student.services.data.PageGroup;
 import tds.student.services.data.TestOpportunity;
@@ -60,7 +61,7 @@ public class ContentHandler extends BaseContentRendererController
 
   @Autowired
   @Qualifier("integrationPrintService")
-  PrintServiceImpl _printService;
+  PrintService _printService;
 
   @RequestMapping (value = "TestShell.axd/getPageContent", produces = "application/xml")
   @ResponseBody

--- a/student/src/main/java/tds/student/web/handlers/ContentHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/ContentHandler.java
@@ -15,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,13 +30,7 @@ import tds.itemrenderer.data.ITSTypes.ITSEntityType;
 import tds.itemrenderer.data.InvalidDataException;
 import tds.itemrenderer.data.ItemRender;
 import tds.itemrenderer.data.ItemRenderGroup;
-import tds.itemrenderer.web.ITSDocumentXmlSerializable;
-import tds.itemrenderer.web.XmlWriter;
-import tds.itemrenderer.webcontrols.ErrorCategories;
-import tds.itemrenderer.webcontrols.PageLayout;
-import tds.itemrenderer.webcontrols.rendererservlet.ContentRenderingException;
-import tds.itemrenderer.webcontrols.rendererservlet.RendererServlet;
-import tds.student.services.PrintService;
+import tds.student.services.PrintServiceImpl;
 import tds.student.services.abstractions.IContentService;
 import tds.student.services.abstractions.IResponseService;
 import tds.student.services.data.ItemResponse;
@@ -44,7 +39,7 @@ import tds.student.services.data.TestOpportunity;
 import tds.student.web.StudentContext;
 import tds.student.web.StudentContextException;
 import tds.student.web.StudentSettings;
-import AIR.Common.Web.ContentType;
+
 import TDS.Shared.Exceptions.ReturnStatusException;
 
 @Scope ("prototype")
@@ -64,7 +59,8 @@ public class ContentHandler extends BaseContentRendererController
   private IContentService     _contentService;
 
   @Autowired
-  PrintService                _printService;
+  @Qualifier("integrationPrintService")
+  PrintServiceImpl _printService;
 
   @RequestMapping (value = "TestShell.axd/getPageContent", produces = "application/xml")
   @ResponseBody

--- a/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
@@ -8,15 +8,14 @@
  ******************************************************************************/
 package tds.student.web.handlers;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import AIR.Common.TDSLogger.ITDSLogger;
+import AIR.Common.Web.Session.HttpContext;
+import AIR.Common.Web.TDSReplyCode;
+import AIR.Common.data.ResponseData;
+import TDS.Shared.Data.ReturnStatus;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import TDS.Shared.Exceptions.TDSSecurityException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
 import org.apache.http.HttpStatus;
@@ -31,11 +30,19 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.util.HtmlUtils;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import tds.itemrenderer.data.AccLookup;
 import tds.itemrenderer.data.AccProperties;
-import tds.student.services.PrintServiceImpl;
 import tds.student.services.abstractions.IOpportunityService;
 import tds.student.services.abstractions.IResponseService;
+import tds.student.services.abstractions.PrintService;
 import tds.student.services.data.ApprovalInfo;
 import tds.student.services.data.ApprovalInfo.OpportunityApprovalStatus;
 import tds.student.services.data.ItemResponse;
@@ -55,15 +62,6 @@ import tds.student.sql.data.ToolUsed;
 import tds.student.web.StudentContext;
 import tds.student.web.TestManager;
 import tds.student.web.data.TestShellAudit;
-import AIR.Common.TDSLogger.ITDSLogger;
-import AIR.Common.Web.TDSReplyCode;
-import AIR.Common.Web.Session.HttpContext;
-import AIR.Common.data.ResponseData;
-import TDS.Shared.Data.ReturnStatus;
-import TDS.Shared.Exceptions.ReturnStatusException;
-import TDS.Shared.Exceptions.TDSSecurityException;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author mpatel
@@ -86,7 +84,7 @@ public class TestShellHandler extends TDSHandler
   private IResponseRepository    _responseRepository;
   @Autowired
   @Qualifier("integrationPrintService")
-  private PrintServiceImpl _printService;
+  private PrintService _printService;
   @Autowired
   private ITDSLogger             _tdsLogger;
 

--- a/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -83,6 +84,7 @@ public class TestShellHandler extends TDSHandler
   @Autowired
   private IResponseRepository    _responseRepository;
   @Autowired
+  @Qualifier("integrationPrintService")
   private PrintService           _printService;
   @Autowired
   private ITDSLogger             _tdsLogger;

--- a/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
@@ -33,7 +33,7 @@ import org.springframework.web.util.HtmlUtils;
 
 import tds.itemrenderer.data.AccLookup;
 import tds.itemrenderer.data.AccProperties;
-import tds.student.services.PrintService;
+import tds.student.services.PrintServiceImpl;
 import tds.student.services.abstractions.IOpportunityService;
 import tds.student.services.abstractions.IResponseService;
 import tds.student.services.data.ApprovalInfo;
@@ -78,6 +78,7 @@ public class TestShellHandler extends TDSHandler
   @Autowired
   private IOpportunityRepository _oppRepository;
   @Autowired
+  @Qualifier("integrationOpportunityService")
   private IOpportunityService    _oppService;
   @Autowired
   private IResponseService       _responseService;
@@ -85,7 +86,7 @@ public class TestShellHandler extends TDSHandler
   private IResponseRepository    _responseRepository;
   @Autowired
   @Qualifier("integrationPrintService")
-  private PrintService           _printService;
+  private PrintServiceImpl _printService;
   @Autowired
   private ITDSLogger             _tdsLogger;
 

--- a/student/src/test/java/tds/student/services/PrintServiceTest.java
+++ b/student/src/test/java/tds/student/services/PrintServiceTest.java
@@ -25,7 +25,7 @@ import tds.student.services.data.ItemResponse;
 import tds.student.services.data.PageGroup;
 import tds.student.services.data.TestOpportunity;
 import tds.student.sql.data.OpportunityInstance;
-import tds.student.sql.repository.OpportunityRepository;
+
 import AIR.test.framework.AbstractTest;
 import TDS.Shared.Exceptions.ReturnStatusException;
 
@@ -41,7 +41,7 @@ public class PrintServiceTest extends AbstractTest
   private static final Logger _logger               = LoggerFactory.getLogger (PrintServiceTest.class);
 
   @Autowired
-  PrintService          printService ;
+  PrintServiceImpl printService ;
 
   // Suceess Test Case
   @Test

--- a/student/src/test/java/tds/student/services/PrintServiceTest.java
+++ b/student/src/test/java/tds/student/services/PrintServiceTest.java
@@ -8,8 +8,8 @@
  ******************************************************************************/
 package tds.student.services;
 
-import java.sql.SQLException;
-
+import AIR.test.framework.AbstractTest;
+import TDS.Shared.Exceptions.ReturnStatusException;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -17,17 +17,18 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.sql.SQLException;
+
 import tds.itemrenderer.data.AccLookup;
+import tds.student.services.abstractions.PrintService;
 import tds.student.services.data.ItemResponse;
 import tds.student.services.data.PageGroup;
 import tds.student.services.data.TestOpportunity;
 import tds.student.sql.data.OpportunityInstance;
-
-import AIR.test.framework.AbstractTest;
-import TDS.Shared.Exceptions.ReturnStatusException;
 
 /**
  * @author temp_rreddy
@@ -41,7 +42,8 @@ public class PrintServiceTest extends AbstractTest
   private static final Logger _logger               = LoggerFactory.getLogger (PrintServiceTest.class);
 
   @Autowired
-  PrintServiceImpl printService ;
+  @Qualifier("legacyPrintService")
+  PrintService printService ;
 
   // Suceess Test Case
   @Test

--- a/student/src/test/java/tds/student/services/remote/RemotePrintServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemotePrintServiceTest.java
@@ -73,7 +73,7 @@ public class RemotePrintServiceTest {
     pageGroup.add(new ItemResponse(opportunityItem1));
     pageGroup.add(new ItemResponse(opportunityItem2));
 
-    boolean isSuccessful = service.printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, mockOpportunityInstance, pageGroup, requestParams);
+    boolean isSuccessful = service.printPassage(mockOpportunityInstance, pageGroup, requestParams);
     assertThat(isSuccessful).isTrue();
 
     verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
@@ -99,7 +99,7 @@ public class RemotePrintServiceTest {
     final OpportunityItem opportunityItem1 = new OpportunityItem();
     final PageGroup pageGroup = new PageGroup(opportunityItem1);
 
-    boolean isSuccessful = service.printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, mockOpportunityInstance, pageGroup, requestParams);
+    boolean isSuccessful = service.printPassage(mockOpportunityInstance, pageGroup, requestParams);
     assertThat(isSuccessful).isFalse();
     verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
   }
@@ -110,7 +110,7 @@ public class RemotePrintServiceTest {
     final PageGroup pageGroup = new PageGroup(opportunityItem1);
     pageGroup.add(new ItemResponse(opportunityItem1));
 
-    boolean isSuccessful = service.printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, mockOpportunityInstance, pageGroup, StringUtils.EMPTY);
+    boolean isSuccessful = service.printPassage(mockOpportunityInstance, pageGroup, StringUtils.EMPTY);
     assertThat(isSuccessful).isFalse();
     verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
   }
@@ -195,7 +195,7 @@ public class RemotePrintServiceTest {
     AccLookup accLookup = new AccLookup();
     accLookup.add("Braille Type", "TDS_BT_G1");
 
-    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    boolean isSuccessful = service.printPassageBraille(testOpportunity, pageGroup, accLookup);
     assertThat(isSuccessful).isTrue();
 
     verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
@@ -253,7 +253,7 @@ public class RemotePrintServiceTest {
     accLookup.add("Braille Type", "TDS_BT_G1");
     accLookup.add("Braille Transcript", "TDS_BrailleTrans1");
 
-    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    boolean isSuccessful = service.printPassageBraille(testOpportunity, pageGroup, accLookup);
     assertThat(isSuccessful).isTrue();
 
     verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
@@ -288,7 +288,7 @@ public class RemotePrintServiceTest {
 
     AccLookup accLookup = new AccLookup();
 
-    service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    service.printPassageBraille(testOpportunity, pageGroup, accLookup);
   }
 
   @Test
@@ -321,7 +321,7 @@ public class RemotePrintServiceTest {
 
     when(mockContentService.getContent(passagePath, accLookup)).thenReturn(document);
 
-    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    boolean isSuccessful = service.printPassageBraille(testOpportunity, pageGroup, accLookup);
     assertThat(isSuccessful).isFalse();
 
     verify(mockContentService).getContent(passagePath, accLookup);
@@ -356,7 +356,7 @@ public class RemotePrintServiceTest {
 
     when(mockContentService.getContent(passagePath, accLookup)).thenReturn(document);
 
-    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    boolean isSuccessful = service.printPassageBraille(testOpportunity, pageGroup, accLookup);
     assertThat(isSuccessful).isFalse();
 
     verify(mockContentService).getContent(passagePath, accLookup);
@@ -396,7 +396,7 @@ public class RemotePrintServiceTest {
 
     when(mockContentService.getContent(passagePath, accLookup)).thenReturn(document);
 
-    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    boolean isSuccessful = service.printPassageBraille(testOpportunity, pageGroup, accLookup);
     assertThat(isSuccessful).isTrue();
 
     verify(mockContentService).getContent(passagePath, accLookup);

--- a/student/src/test/java/tds/student/services/remote/RemotePrintServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemotePrintServiceTest.java
@@ -1,0 +1,599 @@
+package tds.student.services.remote;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+import tds.itemrenderer.data.AccLookup;
+import tds.itemrenderer.data.ITSAttachment;
+import tds.itemrenderer.data.ITSContent;
+import tds.itemrenderer.data.ITSDocumentXml;
+import tds.student.services.abstractions.IContentService;
+import tds.student.services.abstractions.PrintService;
+import tds.student.services.data.ItemResponse;
+import tds.student.services.data.PageGroup;
+import tds.student.services.data.TestOpportunity;
+import tds.student.sql.data.OpportunityInstance;
+import tds.student.sql.data.OpportunityItem;
+import tds.student.sql.data.TestConfig;
+import tds.student.sql.repository.ExamRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemotePrintServiceTest {
+  @Mock
+  private PrintService legacyPrintService;
+
+  @Mock
+  private ExamRepository mockExamRepository;
+
+  @Mock
+  private IContentService mockContentService;
+
+  private PrintService service;
+
+  @Captor
+  private ArgumentCaptor<ExamPrintRequest> examPrintRequestCaptor;
+
+  final OpportunityInstance mockOpportunityInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+  @Before
+  public void setUp() {
+    service = new RemotePrintService(legacyPrintService, true, false, mockExamRepository, mockContentService);
+  }
+
+  @Test
+  public void shouldPrintPassageSuccessfullyMultiItem() throws ReturnStatusException {
+    final String requestParams = "request";
+
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setStimulusFile("/path/to/stim");
+    opportunityItem1.setPosition(1);
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    boolean isSuccessful = service.printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, mockOpportunityInstance, pageGroup, requestParams);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Passage for Items 1-2");
+    assertThat(printRequest.getItemPosition()).isEqualTo(0);
+    assertThat(printRequest.getPagePosition()).isEqualTo(pageGroup.getNumber());
+    assertThat(printRequest.getParameters()).isEqualTo(requestParams);
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/stim");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE);
+  }
+
+  @Test
+  public void shouldReturnFalseForEmptyPageGroupPrintPassage() throws ReturnStatusException {
+    final String requestParams = "request";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+
+    boolean isSuccessful = service.printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, mockOpportunityInstance, pageGroup, requestParams);
+    assertThat(isSuccessful).isFalse();
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldReturnFalseForEmptyRequestValPrintPassage() throws ReturnStatusException {
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+
+    boolean isSuccessful = service.printPassage(ExamPrintRequest.REQUEST_TYPE_PRINT_PASSAGE, mockOpportunityInstance, pageGroup, StringUtils.EMPTY);
+    assertThat(isSuccessful).isFalse();
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldPrintItemSuccessfully() throws ReturnStatusException {
+    final String requestParams = "request";
+
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setItemFile("/path/to/stim");
+    opportunityItem1.setPosition(1);
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+
+    boolean isSuccessful = service.printItem(mockOpportunityInstance, itemResponse, requestParams);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Item 1");
+    assertThat(printRequest.getItemPosition()).isEqualTo(opportunityItem1.getPosition());
+    assertThat(printRequest.getPagePosition()).isEqualTo(opportunityItem1.getPage());
+    assertThat(printRequest.getParameters()).isEqualTo(requestParams);
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/stim");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM);
+  }
+
+  @Test
+  public void shouldFailToPrintNullResponseToPrintItem() throws ReturnStatusException {
+    final String requestParams = "request";
+    boolean isSuccessful = service.printItem(mockOpportunityInstance, null, requestParams);
+    assertThat(isSuccessful).isFalse();
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldFailToPrintEmptyFilePathToPrintItem() throws ReturnStatusException {
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setPosition(1);
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+
+    boolean isSuccessful = service.printItem(mockOpportunityInstance, itemResponse, StringUtils.EMPTY);
+    assertThat(isSuccessful).isFalse();
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldSuccessfullyPrintPassageBrailleNoTranscript() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setStimulusFile("/path/to/stim");
+    opportunityItem1.setPosition(1);
+
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final ITSAttachment brailleAttachment = new ITSAttachment();
+    brailleAttachment.setType("Braille Type");
+    brailleAttachment.setFile("/path/to/braille/file");
+    brailleAttachment.setSubType("uncontracted");
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment));
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.setDocument(document);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+
+    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Passage for Items 1-2 (Braille Type)");
+    assertThat(printRequest.getItemPosition()).isEqualTo(0);
+    assertThat(printRequest.getPagePosition()).isEqualTo(opportunityItem1.getPage());
+    assertThat(printRequest.getParameters()).isEqualTo("FileFormat:BRAILLE TYPE");
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/braille/file");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE);
+    assertThat(pageGroup.isPrinted()).isTrue();
+  }
+
+  @Test
+  public void shouldSuccessfullyPrintPassageBrailleWithTranscript() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setStimulusFile("/path/to/stim");
+    opportunityItem1.setPosition(1);
+
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final ITSAttachment brailleAttachment1 = new ITSAttachment();
+    brailleAttachment1.setType("Braille Type");
+    brailleAttachment1.setFile("/path/to/braille/file");
+    brailleAttachment1.setSubType("uncontracted");
+
+    final ITSAttachment brailleAttachment2 = new ITSAttachment();
+    brailleAttachment2.setType("Braille Transcript");
+    brailleAttachment2.setFile("/path/to/braille/file2");
+    brailleAttachment2.setSubType("uncontracted_transcript");
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment1, brailleAttachment2));
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.setDocument(document);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+    accLookup.add("Braille Transcript", "TDS_BrailleTrans1");
+
+    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Passage and Transcript for Items 1-2 (Braille Type)");
+    assertThat(printRequest.getItemPosition()).isEqualTo(0);
+    assertThat(printRequest.getPagePosition()).isEqualTo(opportunityItem1.getPage());
+    assertThat(printRequest.getParameters()).isEqualTo("FileFormat:BRAILLE TYPE");
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/braille/file;/path/to/braille/file2");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE);
+    assertThat(pageGroup.isPrinted()).isTrue();
+  }
+
+  @Test(expected = ReturnStatusException.class)
+  public void shouldThrowForEmptyXmlPath() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setStimulusFile(StringUtils.EMPTY);
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    AccLookup accLookup = new AccLookup();
+
+    service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+  }
+
+  @Test
+  public void shouldReturnFalseForNoContentPrintPassage() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String passagePath = "/path/to/stim";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setStimulusFile(passagePath);
+    opportunityItem1.setPosition(1);
+
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final ITSAttachment brailleAttachment = new ITSAttachment();
+    brailleAttachment.setType("Braille Type");
+    brailleAttachment.setFile("/path/to/braille/file");
+    brailleAttachment.setSubType("uncontracted");
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment));
+    final ITSDocumentXml document = new ITSDocumentXml();
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+
+    when(mockContentService.getContent(passagePath, accLookup)).thenReturn(document);
+
+    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    assertThat(isSuccessful).isFalse();
+
+    verify(mockContentService).getContent(passagePath, accLookup);
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldReturnFalseForEmptyBrailleAttachments() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String passagePath = "/path/to/stim";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setStimulusFile(passagePath);
+    opportunityItem1.setPosition(1);
+
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(new ArrayList<ITSAttachment>());
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+
+    when(mockContentService.getContent(passagePath, accLookup)).thenReturn(document);
+
+    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    assertThat(isSuccessful).isFalse();
+
+    verify(mockContentService).getContent(passagePath, accLookup);
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldSuccessfullyPrintPassageBrailleNoTranscriptContentFromContentService() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String passagePath = "/path/to/stim";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setStimulusFile(passagePath);
+    opportunityItem1.setPosition(1);
+
+    final OpportunityItem opportunityItem2 = new OpportunityItem();
+    opportunityItem2.setPosition(2);
+
+    final ITSAttachment brailleAttachment = new ITSAttachment();
+    brailleAttachment.setType("Braille Type");
+    brailleAttachment.setFile("/path/to/braille/file");
+    brailleAttachment.setSubType("uncontracted");
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment));
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final PageGroup pageGroup = new PageGroup(opportunityItem1);
+    pageGroup.add(new ItemResponse(opportunityItem1));
+    pageGroup.add(new ItemResponse(opportunityItem2));
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+
+    when(mockContentService.getContent(passagePath, accLookup)).thenReturn(document);
+
+    boolean isSuccessful = service.printPassageBraille(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE, testOpportunity, pageGroup, accLookup);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockContentService).getContent(passagePath, accLookup);
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Passage for Items 1-2 (Braille Type)");
+    assertThat(printRequest.getItemPosition()).isEqualTo(0);
+    assertThat(printRequest.getPagePosition()).isEqualTo(opportunityItem1.getPage());
+    assertThat(printRequest.getParameters()).isEqualTo("FileFormat:BRAILLE TYPE");
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/braille/file");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE);
+  }
+
+  @Test
+  public void shouldSuccessfullyPrintItemBrailleNoTranscriptContentFromContentService() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String itemPath = "/path/to/item";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setPosition(1);
+
+    final ITSAttachment brailleAttachment = new ITSAttachment();
+    brailleAttachment.setType("Braille Type");
+    brailleAttachment.setFile("/path/to/braille/file");
+    brailleAttachment.setSubType("uncontracted");
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment));
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+    itemResponse.setFilePath(itemPath);
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+
+    when(mockContentService.getContent(itemPath, accLookup)).thenReturn(document);
+
+    boolean isSuccessful = service.printItemBraille(testOpportunity, itemResponse, accLookup);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockContentService).getContent(itemPath, accLookup);
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Item 1 (Braille Type)");
+    assertThat(printRequest.getItemPosition()).isEqualTo(1);
+    assertThat(printRequest.getPagePosition()).isEqualTo(opportunityItem1.getPage());
+    assertThat(printRequest.getParameters()).isEqualTo("FileFormat:BRAILLE TYPE");
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/braille/file");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM);
+  }
+
+  @Test
+  public void shouldSuccessfullyPrintItemBrailleWithTranscript() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String itemPath = "/path/to/item";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setPosition(1);
+
+    final ITSAttachment brailleAttachment1 = new ITSAttachment();
+    brailleAttachment1.setType("Braille Type");
+    brailleAttachment1.setFile("/path/to/braille/file");
+    brailleAttachment1.setSubType("uncontracted");
+
+    final ITSAttachment brailleAttachment2 = new ITSAttachment();
+    brailleAttachment2.setType("Braille Transcript");
+    brailleAttachment2.setFile("/path/to/braille/file2");
+    brailleAttachment2.setSubType("uncontracted_transcript");
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment1, brailleAttachment2));
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+    itemResponse.setFilePath(itemPath);
+    itemResponse.setDocument(document);
+
+    AccLookup accLookup = new AccLookup();
+    accLookup.add("Braille Type", "TDS_BT_G1");
+    accLookup.add("Braille Transcript", "TDS_BrailleTrans1");
+
+    boolean isSuccessful = service.printItemBraille(testOpportunity, itemResponse, accLookup);
+    assertThat(isSuccessful).isTrue();
+
+    verify(mockContentService, never()).getContent(itemPath, accLookup);
+    verify(mockExamRepository).createPrintRequest(examPrintRequestCaptor.capture());
+    ExamPrintRequest printRequest = examPrintRequestCaptor.getValue();
+
+    assertThat(printRequest.getExamId()).isEqualTo(mockOpportunityInstance.getExamId());
+    assertThat(printRequest.getSessionId()).isEqualTo(mockOpportunityInstance.getSessionKey());
+    assertThat(printRequest.getId()).isNotNull();
+    assertThat(printRequest.getDescription()).isEqualTo("Item and Transcript 1 (Braille Type)");
+    assertThat(printRequest.getItemPosition()).isEqualTo(1);
+    assertThat(printRequest.getPagePosition()).isEqualTo(opportunityItem1.getPage());
+    assertThat(printRequest.getParameters()).isEqualTo("FileFormat:BRAILLE TYPE");
+    assertThat(printRequest.getDeniedAt()).isNull();
+    assertThat(printRequest.getApprovedAt()).isNull();
+    assertThat(printRequest.getReasonDenied()).isNull();
+    assertThat(printRequest.getValue()).isEqualTo("/path/to/braille/file;/path/to/braille/file2");
+    assertThat(printRequest.getType()).isEqualTo(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM);
+  }
+
+  @Test(expected = ReturnStatusException.class)
+  public void shouldThrowForEmptyXmlPathPrintItemBraille() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setPosition(1);
+
+    final ITSAttachment brailleAttachment = new ITSAttachment();
+    brailleAttachment.setType("Braille Type");
+    brailleAttachment.setFile("/path/to/braille/file");
+    brailleAttachment.setSubType("uncontracted");
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(Arrays.asList(brailleAttachment));
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+    itemResponse.setDocument(document);
+    AccLookup accLookup = new AccLookup();
+
+    service.printItemBraille(testOpportunity, itemResponse, accLookup);
+  }
+
+  @Test
+  public void shouldReturnFalseForNoContentPrintItemBraille() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String itemPath = "/path/to/item";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setPosition(1);
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+    itemResponse.setFilePath(itemPath);
+    itemResponse.setDocument(document);
+
+    AccLookup accLookup = new AccLookup();
+
+    boolean isSuccessful = service.printItemBraille(testOpportunity, itemResponse, accLookup);
+    assertThat(isSuccessful).isFalse();
+
+    verify(mockContentService, never()).getContent(itemPath, accLookup);
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+
+  @Test
+  public void shouldReturnFalseForEmptyBrailleAttachmentsPrintItemBraille() throws ReturnStatusException {
+    final TestOpportunity testOpportunity = new TestOpportunity(mockOpportunityInstance, "testKey", "testId", "ENU", new TestConfig());
+    final String itemPath = "/path/to/item";
+    final OpportunityItem opportunityItem1 = new OpportunityItem();
+    opportunityItem1.setPage(3);
+    opportunityItem1.setPosition(1);
+
+    final ITSContent content = new ITSContent();
+    content.setLanguage("ENU");
+    content.setAttachments(new ArrayList<ITSAttachment>());
+
+    final ITSDocumentXml document = new ITSDocumentXml();
+    document.addContent(content);
+
+    final ItemResponse itemResponse = new ItemResponse(opportunityItem1);
+    itemResponse.setFilePath(itemPath);
+    itemResponse.setDocument(document);
+
+    AccLookup accLookup = new AccLookup();
+
+    boolean isSuccessful = service.printItemBraille(testOpportunity, itemResponse, accLookup);
+    assertThat(isSuccessful).isFalse();
+
+    verify(mockContentService, never()).getContent(itemPath, accLookup);
+    verify(mockExamRepository, never()).createPrintRequest(isA(ExamPrintRequest.class));
+  }
+}

--- a/student/src/test/java/tds/student/sql/repository/RemoteExamRepositoryTest.java
+++ b/student/src/test/java/tds/student/sql/repository/RemoteExamRepositoryTest.java
@@ -28,6 +28,7 @@ import tds.common.Response;
 import tds.common.ValidationError;
 import tds.exam.Exam;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamPrintRequest;
 import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
 import tds.exam.OpenExamRequest;
@@ -201,5 +202,33 @@ public class RemoteExamRepositoryTest {
     when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
       .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Invalid", ERROR_JSON.getBytes(), null));
     remoteExamRepository.findExamSegments(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+  }
+
+  @Test
+  public void shouldCreatePrintRequest() throws Exception {
+    ExamPrintRequest examPrintRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+      .withExamId(UUID.randomUUID())
+      .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+      .withValue("Some value")
+      .build();
+
+    when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+      .thenReturn(new ResponseEntity(HttpStatus.OK));
+
+    remoteExamRepository.createPrintRequest(examPrintRequest);
+  }
+
+  @Test(expected = ReturnStatusException.class)
+  public void shouldThrowForFailedPrintRequest() throws Exception {
+    ExamPrintRequest examPrintRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+      .withExamId(UUID.randomUUID())
+      .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+      .withValue("Some value")
+      .build();
+
+    when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+      .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Invalid", ERROR_JSON.getBytes(), null));
+
+    remoteExamRepository.createPrintRequest(examPrintRequest);
   }
 }

--- a/student/src/test/java/tds/student/web/handlers/ContentHandlerTest.java
+++ b/student/src/test/java/tds/student/web/handlers/ContentHandlerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import tds.itemrenderer.data.AccLookup;
-import tds.student.services.PrintService;
+import tds.student.services.PrintServiceImpl;
 import tds.student.services.abstractions.IContentService;
 import tds.student.services.abstractions.IResponseService;
 import tds.student.services.data.TestOpportunity;
@@ -53,7 +53,7 @@ public class ContentHandlerTest extends AbstractTest
   IContentService        _contentService;
 
   @Mock
-  PrintService           _printService;
+  PrintServiceImpl _printService;
 
   private MockMvc        _mockMvc;
 

--- a/student/src/test/java/tds/student/web/handlers/ContentHandlerTest.java
+++ b/student/src/test/java/tds/student/web/handlers/ContentHandlerTest.java
@@ -8,9 +8,7 @@
  ******************************************************************************/
 package tds.student.web.handlers;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import AIR.test.framework.AbstractTest;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -21,16 +19,19 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import tds.itemrenderer.data.AccLookup;
-import tds.student.services.PrintServiceImpl;
 import tds.student.services.abstractions.IContentService;
 import tds.student.services.abstractions.IResponseService;
+import tds.student.services.abstractions.PrintService;
 import tds.student.services.data.TestOpportunity;
 import tds.student.web.StudentSettings;
-import AIR.test.framework.AbstractTest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * @author jmambo
@@ -53,7 +54,8 @@ public class ContentHandlerTest extends AbstractTest
   IContentService        _contentService;
 
   @Mock
-  PrintServiceImpl _printService;
+  @Qualifier("legacyPrintService")
+  PrintService _printService;
 
   private MockMvc        _mockMvc;
 

--- a/student/src/test/resources/test-context.xml
+++ b/student/src/test/resources/test-context.xml
@@ -56,7 +56,6 @@
 	<!-- For ResponseRepositoryTest -->	
 	<beans:bean id="iResponseRepository" class="tds.student.sql.repository.ResponseRepository"/>
 	<!-- For PrintServiceTest -->
-	<beans:bean id="printService" class="tds.student.services.PrintServiceImpl"/>
 	<beans:bean id="iContentService" class="tds.student.services.ContentService"/>
 	<beans:bean id="ibRepository" class="tds.student.sql.repository.ItemBankRepository"/>
 	<beans:bean id="iOppRepository" class="tds.student.sql.repository.OpportunityRepository"/>

--- a/student/src/test/resources/test-context.xml
+++ b/student/src/test/resources/test-context.xml
@@ -56,7 +56,7 @@
 	<!-- For ResponseRepositoryTest -->	
 	<beans:bean id="iResponseRepository" class="tds.student.sql.repository.ResponseRepository"/>
 	<!-- For PrintServiceTest -->
-	<beans:bean id="printService" class="tds.student.services.PrintService"/>
+	<beans:bean id="printService" class="tds.student.services.PrintServiceImpl"/>
 	<beans:bean id="iContentService" class="tds.student.services.ContentService"/>
 	<beans:bean id="ibRepository" class="tds.student.sql.repository.ItemBankRepository"/>
 	<beans:bean id="iOppRepository" class="tds.student.sql.repository.OpportunityRepository"/>


### PR DESCRIPTION
Implementation of the RemotePrintService, which will create ExamPrintRequests to send to the ExamService.

Please reference PrintServiceImpl (previously PrintService) for the prior implementation of this code.

I have renamed `PrintService` to `PrintServiceImpl` and created an interface `Print Service` which the (legacy) `PrintServiceImpl` and `RemotePrintService` now implements.