### PR TITLE
Segment approval integration

### DIFF
--- a/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
@@ -40,6 +40,7 @@ import tds.student.sql.data.TestSegment;
 import tds.student.sql.data.TestSelection;
 import tds.student.sql.data.TestSession;
 import tds.student.sql.data.Testee;
+import tds.student.sql.repository.ExamSegmentRepository;
 
 @Service("integrationOpportunityService")
 @Scope("prototype")
@@ -49,6 +50,7 @@ public class RemoteOpportunityService implements IOpportunityService {
   private final boolean isRemoteExamCallsEnabled;
   private final boolean isLegacyCallsEnabled;
   private final ExamRepository examRepository;
+  private final ExamSegmentRepository examSegmentRepository;
   private final TestOpportunityExamMapDao testOpportunityExamMapDao;
 
   @Autowired
@@ -57,6 +59,7 @@ public class RemoteOpportunityService implements IOpportunityService {
     @Value("${tds.exam.remote.enabled}") final Boolean remoteExamCallsEnabled,
     @Value("${tds.exam.legacy.enabled}") final Boolean legacyCallsEnabled,
     final ExamRepository examRepository,
+    final ExamSegmentRepository examSegmentRepository,
     final TestOpportunityExamMapDao testOpportunityExamMapDao) {
 
     if (!remoteExamCallsEnabled && !legacyCallsEnabled) {
@@ -68,6 +71,7 @@ public class RemoteOpportunityService implements IOpportunityService {
     this.isLegacyCallsEnabled = legacyCallsEnabled;
     this.examRepository = examRepository;
     this.testOpportunityExamMapDao = testOpportunityExamMapDao;
+    this.examSegmentRepository = examSegmentRepository;
   }
 
   @Override
@@ -356,7 +360,7 @@ public class RemoteOpportunityService implements IOpportunityService {
       return;
     }
 
-    examRepository.exitSegment(oppInstance.getExamId(), segmentPosition);
+    examSegmentRepository.exitSegment(oppInstance.getExamId(), segmentPosition);
   }
 
   private static TestConfig mapExamConfigurationToTestConfig(ExamConfiguration examConfiguration) {

--- a/student/src/main/java/tds/student/sql/repository/ExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/ExamRepository.java
@@ -105,16 +105,8 @@ public interface ExamRepository {
    *
    * @param examId The id of the exam
    * @param segmentApprovalRequest A {@link tds.exam.SegmentApprovalRequest} containing request data
-   * @throws ReturnStatusException
+   * @throws TDS.Shared.Exceptions.ReturnStatusException
    */
   void waitForSegmentApproval(final UUID examId, final SegmentApprovalRequest segmentApprovalRequest) throws ReturnStatusException;
 
-  /**
-   * Creates a request to exit a segment
-   *
-   * @param examId The exam id of the {@link tds.exam.ExamSegment} to exit
-   * @param segmentPosition The segment position of the {@link tds.exam.ExamSegment} to update
-   * @throws ReturnStatusException
-   */
-  void exitSegment(final UUID examId, final int segmentPosition) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/sql/repository/ExamSegmentRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/ExamSegmentRepository.java
@@ -1,0 +1,20 @@
+package tds.student.sql.repository;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+
+import java.util.UUID;
+
+/**
+ * Repository to interact with exam segment data
+ */
+public interface ExamSegmentRepository {
+
+    /**
+     * Creates a request to exit a segment
+     *
+     * @param examId The exam id of the {@link tds.exam.ExamSegment} to exit
+     * @param segmentPosition The segment position of the {@link tds.exam.ExamSegment} to update
+     * @throws ReturnStatusException
+     */
+    void exitSegment(final UUID examId, final int segmentPosition) throws ReturnStatusException;
+}

--- a/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/RemoteExamRepository.java
@@ -314,25 +314,4 @@ public class RemoteExamRepository implements ExamRepository {
       throw new ReturnStatusException(rce);
     }
   }
-
-  @Override
-  public void exitSegment(final UUID examId, final int segmentPosition) throws ReturnStatusException {
-    HttpHeaders headers = new HttpHeaders();
-    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
-
-    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/%s/exit/%s", examUrl, examId, segmentPosition));
-
-    try {
-      restTemplate.exchange(
-        builder.build().toUri(),
-        HttpMethod.PUT,
-        requestHttpEntity,
-        new ParameterizedTypeReference<NoContentResponseResource>() {
-        });
-    } catch (RestClientException rce) {
-      throw new ReturnStatusException(rce);
-    }
-  }
 }

--- a/student/src/main/java/tds/student/sql/repository/RemoteExamSegmentRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/RemoteExamSegmentRepository.java
@@ -1,0 +1,54 @@
+package tds.student.sql.repository;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+import tds.common.web.resources.NoContentResponseResource;
+
+@Repository
+public class RemoteExamSegmentRepository implements ExamSegmentRepository {
+
+  private final RestTemplate restTemplate;
+  private final String examUrl;
+
+  @Autowired
+  public RemoteExamSegmentRepository(@Qualifier("integrationRestTemplate") final RestTemplate restTemplate,
+                                     @Value("${tds.exam.remote.url}") final String examUrl) {
+    this.restTemplate = restTemplate;
+    this.examUrl = examUrl;
+  }
+  
+  @Override
+  public void exitSegment(final UUID examId, final int segmentPosition) throws ReturnStatusException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<?> requestHttpEntity = new HttpEntity<>(headers);
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(String.format("%s/segments/%s/exit/%d", examUrl, examId, segmentPosition));
+
+    try {
+      restTemplate.exchange(
+        builder.build().toUri(),
+        HttpMethod.PUT,
+        requestHttpEntity,
+        new ParameterizedTypeReference<NoContentResponseResource>() {
+        });
+    } catch (RestClientException rce) {
+      throw new ReturnStatusException(rce);
+    }
+  }
+}

--- a/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
+++ b/student/src/test/java/tds/student/services/remote/RemoteOpportunityServiceTest.java
@@ -41,6 +41,7 @@ import tds.student.sql.data.TestSegment;
 import tds.student.sql.data.TestSession;
 import tds.student.sql.data.Testee;
 import tds.student.sql.repository.ExamRepository;
+import tds.student.sql.repository.ExamSegmentRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -62,6 +63,9 @@ public class RemoteOpportunityServiceTest {
   private ExamRepository examRepository;
 
   @Mock
+  private ExamSegmentRepository examSegmentRepository;
+
+  @Mock
   private TestOpportunityExamMapDao testOpportunityExamMapDao;
 
   @Captor
@@ -69,7 +73,7 @@ public class RemoteOpportunityServiceTest {
 
   @Before
   public void setUp() {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, true, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, true, examRepository, examSegmentRepository, testOpportunityExamMapDao);
   }
 
   @After
@@ -118,7 +122,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldNotExecuteRemoteCallIfNotEnabled() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, false, true, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, false, true, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     Testee testee = new Testee();
     TestSession testSession = new TestSession();
@@ -137,7 +141,7 @@ public class RemoteOpportunityServiceTest {
 
     when(examRepository.openExam(isA(OpenExamRequest.class))).thenReturn(response);
 
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     Testee testee = new Testee();
     TestSession testSession = new TestSession();
@@ -149,12 +153,12 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = IllegalStateException.class)
   public void shouldThrowIfBothImplementationsAreDisabled() {
-    new RemoteOpportunityService(legacyOpportunityService, false, false, examRepository, testOpportunityExamMapDao);
+    new RemoteOpportunityService(legacyOpportunityService, false, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
   }
 
   @Test
   public void shouldGetApprovedStatusNoErrors() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), null);
 
@@ -167,7 +171,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldGetDeniedStatusNoErrors() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_DENIED, ExamStatusStage.OPEN), null);
 
@@ -180,7 +184,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowWithErrorsPresent() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_DENIED, ExamStatusStage.OPEN), null);
 
@@ -191,7 +195,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldReturnApprovalInfo() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamApproval examApproval = new ExamApproval(oppInstance.getExamId(), new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), null);
 
@@ -204,7 +208,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldDenyApproval() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
 
@@ -223,7 +227,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldNotSetStatusIfStatusIsPaused() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
     currentStatus.setStatus(OpportunityStatusType.Paused);
@@ -240,7 +244,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldUpdateStatus() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -256,7 +260,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldReturnTrueForErrorWithFalseCheckStatus() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -273,7 +277,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForReturnStatusFailed() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -288,7 +292,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldReturnFalseForValidationErrorReturned() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
 
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     OpportunityStatus currentStatus = new OpportunityStatus();
@@ -305,7 +309,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForErrorPresent() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
     Response<ExamConfiguration> errorResponse = new Response<>(new ValidationError("uh", "oh!"));
@@ -316,7 +320,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldStartExamAndReturnTestConfig() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     final String assessmentKey = "assessmentKey";
 
@@ -354,7 +358,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldFindExamSegmentsForExamIds() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     ExamSegment seg1 = new ExamSegment.Builder()
       .withSegmentKey("seg1")
@@ -415,7 +419,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test(expected = ReturnStatusException.class)
   public void shouldThrowForErrorsPresentFindExamSegments() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     when(examRepository.findExamSegments(oppInstance.getExamId(), oppInstance.getSessionKey(), oppInstance.getExamBrowserKey()))
       .thenReturn(new Response<List<ExamSegment>>(new ValidationError("why", "not")));
@@ -424,7 +428,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldWaitForSegmentEntry() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     service.waitForSegment(oppInstance, 2, TestSegment.TestSegmentApproval.Entry);
     verify(examRepository).waitForSegmentApproval(eq(oppInstance.getExamId()), segmentApprovalRequestArgumentCaptor.capture());
@@ -438,7 +442,7 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldWaitForSegmentExit() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     service.waitForSegment(oppInstance, 2, TestSegment.TestSegmentApproval.Exit);
     verify(examRepository).waitForSegmentApproval(eq(oppInstance.getExamId()), segmentApprovalRequestArgumentCaptor.capture());
@@ -452,10 +456,10 @@ public class RemoteOpportunityServiceTest {
 
   @Test
   public void shouldExitSegment() throws ReturnStatusException {
-    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, testOpportunityExamMapDao);
+    service = new RemoteOpportunityService(legacyOpportunityService, true, false, examRepository, examSegmentRepository, testOpportunityExamMapDao);
     OpportunityInstance oppInstance = new OpportunityInstance(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     service.exitSegment(oppInstance, 2);
-    verify(examRepository).exitSegment(oppInstance.getExamId(), 2);
+    verify(examSegmentRepository).exitSegment(oppInstance.getExamId(), 2);
   }
 }
 

--- a/student/src/test/java/tds/student/sql/repository/RemoteExamRepositoryTest.java
+++ b/student/src/test/java/tds/student/sql/repository/RemoteExamRepositoryTest.java
@@ -243,7 +243,7 @@ public class RemoteExamRepositoryTest {
     verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
   }
 
-  @Test
+  @Test(expected = ReturnStatusException.class)
   public void shouldThrowForBadResponseWaitForSegmentApproval() throws Exception {
     final UUID examId = UUID.randomUUID();
     final SegmentApprovalRequest request = new SegmentApprovalRequest(UUID.randomUUID(), UUID.randomUUID(), 2, false);
@@ -253,24 +253,4 @@ public class RemoteExamRepositoryTest {
     verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
   }
 
-  @Test
-  public void shouldExitSegment() throws Exception {
-    final UUID examId = UUID.randomUUID();
-    final int segmentPosition = 2;
-
-    when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
-      .thenReturn(new ResponseEntity(HttpStatus.NO_CONTENT));
-    remoteExamRepository.exitSegment(examId, segmentPosition);
-    verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
-  }
-
-  @Test(expected = ReturnStatusException.class)
-  public void shouldThrowForBadResponseExitSegment() throws Exception {
-    final UUID examId = UUID.randomUUID();
-    final int segmentPosition = 2;
-
-    when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
-      .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Invalid", ERROR_JSON.getBytes(), null));
-    remoteExamRepository.exitSegment(examId, segmentPosition);
-  }
 }

--- a/student/src/test/java/tds/student/sql/repository/RemoteExamSegmentRepositoryTest.java
+++ b/student/src/test/java/tds/student/sql/repository/RemoteExamSegmentRepositoryTest.java
@@ -1,0 +1,56 @@
+package tds.student.sql.repository;
+
+import TDS.Shared.Exceptions.ReturnStatusException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteExamSegmentRepositoryTest {
+  private RemoteExamSegmentRepository remoteSegmentExamRepository;
+
+  @Mock
+  private RestTemplate mockRestTemplate;
+
+  @Before
+  public void setUp() {
+    remoteSegmentExamRepository = new RemoteExamSegmentRepository(mockRestTemplate, "http://localhost:8080/exam");
+  }
+
+  @Test
+  public void shouldExitSegment() throws Exception {
+    final UUID examId = UUID.randomUUID();
+    final int segmentPosition = 2;
+
+    when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+      .thenReturn(new ResponseEntity(HttpStatus.NO_CONTENT));
+    remoteSegmentExamRepository.exitSegment(examId, segmentPosition);
+    verify(mockRestTemplate).exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class));
+  }
+
+  @Test(expected = ReturnStatusException.class)
+  public void shouldThrowForBadResponseExitSegment() throws Exception {
+    final UUID examId = UUID.randomUUID();
+    final int segmentPosition = 2;
+
+    when(mockRestTemplate.exchange(isA(URI.class), isA(HttpMethod.class), isA(HttpEntity.class), isA(ParameterizedTypeReference.class)))
+      .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "Invalid", null, null));
+    remoteSegmentExamRepository.exitSegment(examId, segmentPosition);
+  }
+}


### PR DESCRIPTION
This PR covers "exit segment" and "wait for segment approval" exam/student integration. For reference, please see OpportunityService.exitSegment() and OpportunityService.waitForSegment() for legacy implementations.