### PR TITLE
Since the student.library OpportunityStatusChange is being used, we n…

### DIFF
--- a/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteOpportunityService.java
@@ -182,7 +182,7 @@ public class RemoteOpportunityService implements IOpportunityService {
       return isApproved;
     }
 
-    Optional<ValidationError> maybeError = examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name(), statusChange.getReason());
+    Optional<ValidationError> maybeError = examRepository.updateStatus(oppInstance.getExamId(), statusChange.getStatus().name().toLowerCase(), statusChange.getReason());
 
     if (!statusChange.isCheckReturnStatus()) {
       return true;
@@ -246,14 +246,8 @@ public class RemoteOpportunityService implements IOpportunityService {
 
   @Override
   public void denyApproval(final OpportunityInstance oppInstance) throws ReturnStatusException {
-
-    if (isLegacyCallsEnabled) {
-      legacyOpportunityService.denyApproval(oppInstance);
-    }
-
-    if (!isRemoteExamCallsEnabled) {
-      return;
-    }
+    // Since setStatus checks and calls the legacy and remote as needed, we don't need that logic here
+    //  otherwise the legacy service will be called twice
 
     OpportunityStatus opportunityStatus = getStatus(oppInstance);
   


### PR DESCRIPTION
…eed to need to lower case the status name so we get “pending” instead of “Pending” otherwise in ExamService mapping to our enum there brings back an Unknown status.

Addressing TDS-738.  When click No on Is This Your Test it was setting the status in the DB to "Pending" and then couldn't convert to one of our statuses in ExamService so checkApproval returned an issue that then triggered a call to Pause Test which changed the status to Paused.  This changed how the UI displayed as well.  When clicking No, it should go back to the Waiting for TA Approval screen and call checkApproval.  Now it does that.