### PR TITLE
Do not require a filesystem resource when running tests

### DIFF
--- a/student/src/test/resources/performance-integration-context.xml
+++ b/student/src/test/resources/performance-integration-context.xml
@@ -22,7 +22,7 @@
     </context:component-scan>
 
     <context:property-placeholder location="test-setting.properties" order="1" ignore-unresolvable="true" local-override="true"/>
-    <context:property-placeholder location="file:///opt/sbtds/test-db-settings.properties" order="2" ignore-unresolvable="true" local-override="true"/>
+    <context:property-placeholder location="file:///opt/sbtds/test-db-settings.properties" order="2" ignore-resource-not-found="true" ignore-unresolvable="true" local-override="true"/>
 
     <bean id="tdsSettings" class="TDS.Shared.Configuration.TDSSettings" scope="prototype"/>
     <bean id="appSettings" class="AIR.Common.Configuration.ConfigurationSection" scope="prototype"/>

--- a/student/src/test/resources/test-context.xml
+++ b/student/src/test/resources/test-context.xml
@@ -24,7 +24,7 @@
 	<context:component-scan base-package="tds.student.diagnostic"/>
 
 	<context:property-placeholder location="classpath:test-setting.properties" ignore-unresolvable="true" order="900" local-override="true"/>
-	<context:property-placeholder location="file:///opt/sbtds/test-db-settings.properties" order="901" ignore-unresolvable="true" local-override="true"/>
+	<context:property-placeholder location="file:///opt/sbtds/test-db-settings.properties" order="901" ignore-resource-not-found="true" ignore-unresolvable="true" local-override="true"/>
 	
 	<beans:import resource="classpath:opentestsystem.shared.test-db-context-module.xml"/>
 	<beans:import resource="classpath:opentestsystem.shared.tr-api-context-module.xml" />


### PR DESCRIPTION
This PR removes the need for an /opt/sbtds/test-db-settings.properties to exist on the system that is running student tests.

These values were expected to be provided by the properties file:
datasource.jdbcUrl
datasource.username
datasource.password

While the properties file can still be read if it exists, now those properties can alternatively be injected by any spring-standard source (java system properties, environment variables, etc)