### PR TITLE
Add missing diagnostic messages to the systemdiagnostics.xhtml page.

### DIFF
--- a/student/src/main/java/tds/student/web/controls/dummy/GlobalJavascript.java
+++ b/student/src/main/java/tds/student/web/controls/dummy/GlobalJavascript.java
@@ -38,6 +38,10 @@ import TDS.Shared.Messages.IMessageService;
 public class GlobalJavascript extends UIComponentBase
 {
   private static final Logger _logger = LoggerFactory.getLogger (GlobalJavascript.class);
+  static final String CONTEXT_LOGIN_SHELL = "LoginShell";
+  static final String CONTEXT_REVIEW_SHELL = "ReviewShell";
+  static final String CONTEXT_DIAGNOSTIC_SHELL = "DiagnosticShell";
+  static final String CONTEXT_TEST_SHELL = "TestShell";
 
   private String              _contextName;
   private String              _messages;
@@ -87,7 +91,7 @@ public class GlobalJavascript extends UIComponentBase
     writer.WriteAppSettings();
 
     // required on login shell
-    if (StringUtils.equals (getContextName (), "LoginShell")) {
+    if (StringUtils.equals (getContextName (), CONTEXT_LOGIN_SHELL)) {
       writer.writeLoginRequirements ();
       // writer.writeGrades ();
       writer.writeGlobalAccommodations ();
@@ -95,7 +99,7 @@ public class GlobalJavascript extends UIComponentBase
     }
 
     // required for test shell
-    if (StringUtils.equals (getContextName (), "TestShell")) {
+    if (StringUtils.equals (getContextName (), CONTEXT_TEST_SHELL)) {
       writer.writeTestShellButtons ();
       writer.writeManifest ();
     }
@@ -123,7 +127,7 @@ public class GlobalJavascript extends UIComponentBase
       contextList.add (contextName);
 
     // LEGACY CONTEXTS:
-    if (StringUtils.equals (contextName, "LoginShell")) {
+    if (StringUtils.equals (contextName, CONTEXT_LOGIN_SHELL)) {
       // TODO
       /*
        * if (geoServer == GeoType.Login) { contextList.AddRange(new[] {
@@ -133,7 +137,7 @@ public class GlobalJavascript extends UIComponentBase
           "TestInstructions.aspx", "Approval.aspx" };
       // ServerSide
       contextList.addAll (Arrays.asList (pagesArray));
-    } else if (StringUtils.equals (contextName, "TestShell")) {
+    } else if (StringUtils.equals (contextName, CONTEXT_TEST_SHELL)) {
 
       // Removed in new code
       // ServerSide
@@ -145,10 +149,14 @@ public class GlobalJavascript extends UIComponentBase
 
       // ClientSide
       contextList.addAll (Arrays.asList (jsArray));
-    } else if (StringUtils.equals (contextName, "ReviewShell")) {
+    } else if (StringUtils.equals (contextName, CONTEXT_REVIEW_SHELL)) {
       String[] morePages = { "Student.Master", "TestReview.aspx", "TestResults.aspx" };
       // ServerSide
       contextList.addAll (Arrays.asList (morePages));
+
+    } else if (StringUtils.equals(contextName, CONTEXT_DIAGNOSTIC_SHELL)) {
+      String[] pagesArray = { "Default.aspx", "Diagnostics.aspx", "SoundCheck.aspx", "TTSCheck.aspx" };
+      contextList.addAll (Arrays.asList (pagesArray));
     }
 
     return contextList;

--- a/student/src/main/java/tds/student/web/controls/dummy/GlobalJavascript.java
+++ b/student/src/main/java/tds/student/web/controls/dummy/GlobalJavascript.java
@@ -31,9 +31,12 @@ import TDS.Shared.Exceptions.ReadOnlyException;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import TDS.Shared.Messages.IMessageService;
 
-// / <summary>
-// / Adds global variables to a page
-// / </summary>
+/**
+ * This faces component is responsible for fetching resources from the system and providing initial
+ * page-wide javascript values via an embedded <script/> tag.
+ * The javascript values produced include TDS configuration values, I18N translation values,
+ * system information values, etc.
+ */
 @FacesComponent (value = "GlobalJavascript")
 public class GlobalJavascript extends UIComponentBase
 {
@@ -62,6 +65,12 @@ public class GlobalJavascript extends UIComponentBase
     init ();
   }
 
+  /**
+   * Write the super javascript tag to the output stream.
+   *
+   * @param context       The faces context
+   * @throws IOException
+   */
   @Override
   public void encodeAll (FacesContext context) throws IOException {
     ResponseWriter output = context.getResponseWriter ();
@@ -76,6 +85,14 @@ public class GlobalJavascript extends UIComponentBase
     output.write ("</script>");
   }
 
+  /**
+   * Write various javascript property values based upon the context.
+   *
+   * @param output  The output writer
+   * @throws IOException
+   * @throws ReturnStatusException
+   * @throws ReadOnlyException
+   */
   public void writeJavascript (ResponseWriter output) throws IOException, ReturnStatusException, ReadOnlyException {
     GlobalJavascriptWriter writer = new GlobalJavascriptWriter (output, _studentSettings, _configRepository, _itemBankRepository, _iMessageService);
     writer.writeProperties (); // required
@@ -114,6 +131,13 @@ public class GlobalJavascript extends UIComponentBase
      */
   }
 
+  /**
+   * Retrieve the set of contexts required by the given root context.
+   * (e.g. the test shell requires many sub-contexts to provide message translations)
+   *
+   * @param contextName The root context
+   * @return The set of contexts required by the root context
+   */
   public static List<String> getContexts (String contextName) {
     // TODO GeoSettings
     // GeoType geoServer = GeoSettings.GetServerType();
@@ -162,6 +186,13 @@ public class GlobalJavascript extends UIComponentBase
     return contextList;
   }
 
+  /**
+   * Write message translations for all contexts as a javascript/json property: "TDS.Config.messages"
+   *
+   * @param writer  The output writer
+   * @throws IOException
+   * @throws ReturnStatusException
+   */
   private void writeMessages (GlobalJavascriptWriter writer) throws IOException, ReturnStatusException {
     List<String> contextList = getContexts (getContextName ());
 

--- a/student/src/main/webapp/Pages/systemdiagnostics.xhtml
+++ b/student/src/main/webapp/Pages/systemdiagnostics.xhtml
@@ -14,7 +14,6 @@
 	<ui:define name="headerHolder">
 		<tds:ResourcesLink file="~/Scripts/scripts_diagnostics.xml" name="diagnostictool" />
 		<tds:GlobalJavascript contextName="DiagnosticShell" />
-		<script src="#{request.contextPath}/Scripts/Blackbox/blackbox_messages_#{diagnosticsBackingBean.loginClientName}.js" type="text/javascript" />
 	</ui:define>
 
 </ui:composition>

--- a/student/src/test/java/tds/student/web/controls/dummy/GlobalJavascriptTest.java
+++ b/student/src/test/java/tds/student/web/controls/dummy/GlobalJavascriptTest.java
@@ -1,0 +1,27 @@
+package tds.student.web.controls.dummy;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tds.student.web.controls.dummy.GlobalJavascript.CONTEXT_DIAGNOSTIC_SHELL;
+import static tds.student.web.controls.dummy.GlobalJavascript.CONTEXT_LOGIN_SHELL;
+import static tds.student.web.controls.dummy.GlobalJavascript.CONTEXT_REVIEW_SHELL;
+import static tds.student.web.controls.dummy.GlobalJavascript.CONTEXT_TEST_SHELL;
+
+public class GlobalJavascriptTest {
+
+    @Test
+    public void itShouldIncludeAdditionalContextsBasedUponRootContext() {
+        assertThat(GlobalJavascript.getContexts(CONTEXT_LOGIN_SHELL)).hasSize(13);
+        assertThat(GlobalJavascript.getContexts(CONTEXT_REVIEW_SHELL)).hasSize(5);
+        assertThat(GlobalJavascript.getContexts(CONTEXT_TEST_SHELL)).hasSize(20);
+        assertThat(GlobalJavascript.getContexts(CONTEXT_DIAGNOSTIC_SHELL)).hasSize(6);
+    }
+
+    @Test
+    public void itShouldAlwaysIncludeGlobalAndSelfContexts() {
+        assertThat(GlobalJavascript.getContexts("UnknownContext"))
+            .containsOnly("Global", "UnknownContext");
+    }
+
+}


### PR DESCRIPTION
Remove message overrides from blackbox_messages_xxx.js resources in favor of database-provided translations.

This PR adds the contexts needed for message translation to the systemdiagnostics.xhtml page (via the associated DiagnosticShell context.)
I've also removed the client-specific message overrides that were coming from hard-coded messages in TDS_ItemRenderer javascript files.