### PR TITLE
TDS-519: Feature/review exam

### DIFF
--- a/student/pom.xml
+++ b/student/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 		<progman-client.version>3.0.1</progman-client.version>
 		<sb11-mna-client.version>3.0.0</sb11-mna-client.version>
-		<tds-exam-client.version>0.0.14</tds-exam-client.version>
+		<tds-exam-client.version>0.0.15-SNAPSHOT</tds-exam-client.version>
 		<sb11-shared-code.version>3.0.5</sb11-shared-code.version>
 		<tds-common-legacy.version>0.0.6</tds-common-legacy.version>
 		<tds-assessment-client.version>0.0.13</tds-assessment-client.version>

--- a/student/src/main/java/tds/student/services/ReviewTestService.java
+++ b/student/src/main/java/tds/student/services/ReviewTestService.java
@@ -7,19 +7,23 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 import tds.student.services.data.TestOpportunity;
+import tds.student.web.TestManager;
 
 /**
  * A service for
  */
 public interface ReviewTestService {
     /**
-     * Review an
+     * Move an {@link tds.exam.Exam} to the "review" status, meaning a student has answered all the questions and is
+     * ready to review the questions before submitting the exam for scoring.
+     *
      * @param testOpportunity The {@link tds.student.services.data.TestOpportunity}
-     * @param request The {@link javax.servlet.http.HttpServletRequest} representing the HTTP request from the caller
+     * @param testManager     The {@link tds.student.web.TestManager} handling the
+     *                        {@link tds.student.services.data.TestOpportunity}
      * @return A {@link AIR.Common.data.ResponseData} indicating success or failure
      * @throws ReturnStatusException In the event of a failure
-     * @throws IOException In the event the {@link javax.servlet.http.HttpServletRequest} throws
+     * @throws IOException           In the event the {@link javax.servlet.http.HttpServletRequest} throws
      */
     ResponseData<String> reviewTest(final TestOpportunity testOpportunity,
-                                    final HttpServletRequest request) throws ReturnStatusException, IOException;
+                                    final TestManager testManager) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/services/ReviewTestService.java
+++ b/student/src/main/java/tds/student/services/ReviewTestService.java
@@ -1,0 +1,25 @@
+package tds.student.services;
+
+import AIR.Common.data.ResponseData;
+import TDS.Shared.Exceptions.ReturnStatusException;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import tds.student.services.data.TestOpportunity;
+
+/**
+ * A service for
+ */
+public interface ReviewTestService {
+    /**
+     * Review an
+     * @param testOpportunity The {@link tds.student.services.data.TestOpportunity}
+     * @param request The {@link javax.servlet.http.HttpServletRequest} representing the HTTP request from the caller
+     * @return A {@link AIR.Common.data.ResponseData} indicating success or failure
+     * @throws ReturnStatusException In the event of a failure
+     * @throws IOException In the event the {@link javax.servlet.http.HttpServletRequest} throws
+     */
+    ResponseData<String> reviewTest(final TestOpportunity testOpportunity,
+                                    final HttpServletRequest request) throws ReturnStatusException, IOException;
+}

--- a/student/src/main/java/tds/student/services/ReviewTestServiceImpl.java
+++ b/student/src/main/java/tds/student/services/ReviewTestServiceImpl.java
@@ -64,7 +64,7 @@ public class ReviewTestServiceImpl implements ReviewTestService {
             return responseData;
         }
 
-        Optional<ValidationError> maybeValidationError = examRepository.reviewExam(testOpportunity.getOppInstance());
+        final Optional<ValidationError> maybeValidationError = examRepository.reviewExam(testOpportunity.getOppInstance());
         if (maybeValidationError.isPresent()) {
             tdsLogger.applicationError (maybeValidationError.get().getMessage(), "reviewTest", request, null);
             HttpContext.getCurrentContext()
@@ -81,8 +81,9 @@ public class ReviewTestServiceImpl implements ReviewTestService {
      * Executes the legacy implementation of review exam logic.
      *
      * @param testOpportunity The {@link tds.student.services.data.TestOpportunity}
-     * @param request
-     * @return
+     * @param request The HTTP request from the student application for reviewing the
+     *        {@link tds.student.services.data.TestOpportunity}
+     * @return A {@link AIR.Common.data.ResponseData} indicating success or failure
      * @throws ReturnStatusException
      * @throws IOException
      */
@@ -120,7 +121,7 @@ public class ReviewTestServiceImpl implements ReviewTestService {
 
         // put test in review mode
         OpportunityStatusChange statusChange = new OpportunityStatusChange (OpportunityStatusType.Review, true);
-        opportunityService.setStatus (testOpportunity.getOppInstance (), statusChange);
+        opportunityService.setStatus(testOpportunity.getOppInstance(), statusChange);
 
         return new ResponseData<>(TDSReplyCode.OK.getCode(), "OK", null);
     }

--- a/student/src/main/java/tds/student/services/ReviewTestServiceImpl.java
+++ b/student/src/main/java/tds/student/services/ReviewTestServiceImpl.java
@@ -1,0 +1,127 @@
+package tds.student.services;
+
+import AIR.Common.TDSLogger.ITDSLogger;
+import AIR.Common.Web.Session.HttpContext;
+import AIR.Common.Web.TDSReplyCode;
+import AIR.Common.data.ResponseData;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import com.google.common.base.Optional;
+import org.apache.http.HttpStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import tds.common.ValidationError;
+import tds.student.services.abstractions.IOpportunityService;
+import tds.student.services.data.PageList;
+import tds.student.services.data.TestOpportunity;
+import tds.student.sql.data.OpportunityStatusChange;
+import tds.student.sql.data.OpportunityStatusType;
+import tds.student.sql.repository.remote.ExamRepository;
+import tds.student.web.TestManager;
+
+@Service
+@Scope("prototype")
+public class ReviewTestServiceImpl implements ReviewTestService {
+    private final IOpportunityService opportunityService;
+    private final ExamRepository examRepository;
+    private final ITDSLogger tdsLogger;
+    private final boolean isLegacyCallsEnabled;
+    private final boolean isRemoteCallsEnabled;
+
+    @Autowired
+    public ReviewTestServiceImpl(@Qualifier("integrationOpportunityService") final IOpportunityService opportunityService,
+                                 final ExamRepository examRepository,
+                                 final ITDSLogger tdsLogger,
+                                 @Value("${tds.exam.legacy.enabled}") final boolean legacyCallsEnabled,
+                                 @Value("${tds.exam.remote.enabled}") final boolean remoteExamCallsEnabled) {
+        if (!remoteExamCallsEnabled && !legacyCallsEnabled) {
+            throw new IllegalStateException("Remote and legacy calls are both disabled.  Please check progman configuration for 'tds.exam.remote.enabled' and 'tds.exam.legacy.enabled' settings");
+        }
+
+        this.opportunityService = opportunityService;
+        this.examRepository = examRepository;
+        this.tdsLogger = tdsLogger;
+        isLegacyCallsEnabled = legacyCallsEnabled;
+        isRemoteCallsEnabled = remoteExamCallsEnabled;
+    }
+
+    @Override
+    public ResponseData<String> reviewTest(final TestOpportunity testOpportunity,
+                                           final HttpServletRequest request) throws ReturnStatusException, IOException {
+        ResponseData<String> responseData = new ResponseData<>(TDSReplyCode.OK.getCode(), "OK", null);
+
+        if (isLegacyCallsEnabled) {
+            responseData = legacyReviewTest(testOpportunity, request);
+        }
+
+        if (!isRemoteCallsEnabled) {
+            return responseData;
+        }
+
+        Optional<ValidationError> maybeValidationError = examRepository.reviewExam(testOpportunity.getOppInstance());
+        if (maybeValidationError.isPresent()) {
+            tdsLogger.applicationError (maybeValidationError.get().getMessage(), "reviewTest", request, null);
+            HttpContext.getCurrentContext()
+                .getResponse()
+                .sendError(HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
+
+            responseData = null;
+        }
+
+        return responseData;
+    }
+
+    /**
+     * Executes the legacy implementation of review exam logic.
+     *
+     * @param testOpportunity The {@link tds.student.services.data.TestOpportunity}
+     * @param request
+     * @return
+     * @throws ReturnStatusException
+     * @throws IOException
+     */
+    private ResponseData<String> legacyReviewTest(final TestOpportunity testOpportunity,
+                                                  final HttpServletRequest request) throws ReturnStatusException, IOException {
+        // get responses
+        final TestManager testManager = new TestManager(testOpportunity);
+        testManager.LoadResponses(true);
+
+        // check if test length is met
+        testManager.CheckIfTestComplete();
+
+        if (!testManager.IsTestLengthMet()) {
+            // TODO mpatel - Check to see status and message in response and make sure following works
+            final String message = "Review Test: Cannot end test because test length is not met.";
+            tdsLogger.applicationError (message, "reviewTest", request, null);
+            HttpContext.getCurrentContext()
+                .getResponse()
+                .sendError(HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
+
+            return null;
+        }
+
+        // check if all visible pages are completed
+        PageList pageList = testManager.GetVisiblePages();
+        if (!pageList.isAllCompleted()) {
+            final String message = "Review Test: Cannot end test because all the groups have not been answered.";
+            tdsLogger.applicationError (message, "reviewTest", request, null);
+            HttpContext.getCurrentContext()
+                .getResponse()
+                .sendError(HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
+
+            return null;
+        }
+
+        // put test in review mode
+        OpportunityStatusChange statusChange = new OpportunityStatusChange (OpportunityStatusType.Review, true);
+        opportunityService.setStatus (testOpportunity.getOppInstance (), statusChange);
+
+        return new ResponseData<>(TDSReplyCode.OK.getCode(), "OK", null);
+    }
+}

--- a/student/src/main/java/tds/student/services/remote/RemoteAdaptiveService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteAdaptiveService.java
@@ -51,19 +51,19 @@ public class RemoteAdaptiveService implements IAdaptiveService {
       return pageGroup;
     }
 
-//    List<OpportunityItem> items = examItemResponseRepository.createNextItemGroup(testOpportunity.getOppInstance().getExamId(), lastPage, lastPosition);
-//
-//    PageGroup remotePageGroup = new PageGroup(items.get(0));
-//
-//    for (OpportunityItem item : items) {
-//      ItemResponse response = new ItemResponse(item);
-//      response.setPrefetched(true);
-//      remotePageGroup.add(response);
-//    }
-//
-//    if(!legacyCallsEnabled) {
-//      return remotePageGroup;
-//    }
+    List<OpportunityItem> items = examItemResponseRepository.createNextItemGroup(testOpportunity.getOppInstance().getExamId(), lastPage, lastPosition);
+
+    PageGroup remotePageGroup = new PageGroup(items.get(0));
+
+    for (OpportunityItem item : items) {
+      ItemResponse response = new ItemResponse(item);
+      response.setPrefetched(true);
+      remotePageGroup.add(response);
+    }
+
+    if(!legacyCallsEnabled) {
+      return remotePageGroup;
+    }
 
     //TODO - Since this data is used to insert records into the DB we will need to manually move the code over to use
     //the new page group.  Returning the legacy allows us to do data checking.

--- a/student/src/main/java/tds/student/services/remote/RemoteResponseService.java
+++ b/student/src/main/java/tds/student/services/remote/RemoteResponseService.java
@@ -167,8 +167,11 @@ public class RemoteResponseService implements IResponseService {
         opportunityItem.setFormat("FORMAT");
 
         // OpportunityItem#isVisible (mapped to an OpportunityItem in ResponseRepository#readOpportunityItems @ line
-        // 297) never seems to be used (which is why it was not ported to the exam database), so has been omitted from
-        // this mapping.
+        // 297) never seems to be used (which is why it was not ported to the exam database).  The source of the
+        // #isVisible property is the testeeresponse.isinactive column, which is always 0.  The only code that changes
+        // testeeresponse.isinactive is in the _removeunanswered stored procedure, which sets isinactive = 0.  Due to
+        // all this, the OpportunityItem#isVisible will always be set to "true".
+        opportunityItem.setIsVisible(true);
 
         if (item.getResponse().isPresent()) {
           ExamItemResponse itemResponse = item.getResponse().get();

--- a/student/src/main/java/tds/student/sql/repository/remote/ExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/remote/ExamRepository.java
@@ -17,6 +17,7 @@ import tds.exam.ExamPrintRequest;
 import tds.exam.ExamSegment;
 import tds.exam.OpenExamRequest;
 import tds.exam.SegmentApprovalRequest;
+import tds.student.sql.data.OpportunityInstance;
 
 /**
  * Repository to interact with exam data
@@ -81,6 +82,17 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Response<ExamConfiguration> startExam(final UUID examId, final String browserUserAgent) throws ReturnStatusException;
+
+  /**
+   * Final review the {@link tds.exam.Exam} to verify it is complete and ready for transmission to downstream systems
+   * prior to submitting it.
+   *
+   * @param opportunityInstance The {@link tds.student.sql.data.OpportunityInstance} representing the exam to review
+   * @return A {@link tds.common.ValidationError} if the review process fails; otherwise {@code Optional.empty}, which
+   * indicates success
+   * @throws ReturnStatusException
+   */
+  Optional<ValidationError> reviewExam(final OpportunityInstance opportunityInstance) throws ReturnStatusException;
 
   /**
    * Creates a request to fetch {@link tds.exam.ExamSegment}s for an exam

--- a/student/src/main/java/tds/student/sql/repository/remote/ExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/remote/ExamRepository.java
@@ -3,6 +3,7 @@ package tds.student.sql.repository.remote;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import com.google.common.base.Optional;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
@@ -93,7 +94,7 @@ public interface ExamRepository {
    * indicates success
    * @throws ReturnStatusException
    */
-  Optional<ValidationError> reviewExam(final OpportunityInstance opportunityInstance) throws ReturnStatusException;
+  Optional<ValidationError> reviewExam(final OpportunityInstance opportunityInstance) throws ReturnStatusException, IOException;
 
   /**
    * Creates a request to fetch {@link tds.exam.ExamSegment}s for an exam

--- a/student/src/main/java/tds/student/sql/repository/remote/ExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/remote/ExamRepository.java
@@ -84,17 +84,17 @@ public interface ExamRepository {
    * @throws ReturnStatusException
    */
   Response<ExamConfiguration> startExam(final UUID examId, final String browserUserAgent) throws ReturnStatusException;
-
-  /**
-   * Final review the {@link tds.exam.Exam} to verify it is complete and ready for transmission to downstream systems
-   * prior to submitting it.
-   *
-   * @param opportunityInstance The {@link tds.student.sql.data.OpportunityInstance} representing the exam to review
-   * @return A {@link tds.common.ValidationError} if the review process fails; otherwise {@code Optional.empty}, which
-   * indicates success
-   * @throws ReturnStatusException
-   */
-  Optional<ValidationError> reviewExam(final OpportunityInstance opportunityInstance) throws ReturnStatusException, IOException;
+//
+//  /**
+//   * Final review the {@link tds.exam.Exam} to verify it is complete and ready for transmission to downstream systems
+//   * prior to submitting it.
+//   *
+//   * @param opportunityInstance The {@link tds.student.sql.data.OpportunityInstance} representing the exam to review
+//   * @return A {@link tds.common.ValidationError} if the review process fails; otherwise {@code Optional.empty}, which
+//   * indicates success
+//   * @throws ReturnStatusException
+//   */
+//  Optional<ValidationError> reviewExam(final OpportunityInstance opportunityInstance) throws ReturnStatusException, IOException;
 
   /**
    * Creates a request to fetch {@link tds.exam.ExamSegment}s for an exam

--- a/student/src/main/java/tds/student/sql/repository/remote/impl/RemoteExamRepository.java
+++ b/student/src/main/java/tds/student/sql/repository/remote/impl/RemoteExamRepository.java
@@ -255,28 +255,6 @@ public class RemoteExamRepository implements ExamRepository {
   }
 
   @Override
-  public Optional<ValidationError> reviewExam(final OpportunityInstance opportunityInstance) throws ReturnStatusException, IOException {
-    UriComponents uriComponentsBuilder = UriComponentsBuilder.fromUriString("{examUrl}/{examId}/review")
-        .queryParam("sessionId", opportunityInstance.getSessionKey())
-        .queryParam("browserId", opportunityInstance.getExamBrowserKey())
-        .buildAndExpand(examUrl, opportunityInstance.getExamId());
-
-    try {
-      restTemplate.put(uriComponentsBuilder.encode().toUri(), null);
-    } catch (HttpClientErrorException hce) {
-      // An unprocessable entity response means that a validation error was returned by the exam service.  Extract the
-      // message and return it as a ValidationError to the caller.
-      if (hce.getStatusCode().equals(HttpStatus.UNPROCESSABLE_ENTITY)) {
-        return Optional.of(objectMapper.readValue(hce.getResponseBodyAsString(), ValidationError.class));
-      }
-    } catch (RestClientException rce) {
-      throw new ReturnStatusException(rce);
-    }
-
-    return Optional.absent();
-  }
-
-  @Override
   public List<ExamSegment> findExamSegments(UUID examId, UUID sessionId, UUID browserId) throws ReturnStatusException {
     HttpHeaders headers = new HttpHeaders();
     headers.set("Accept", MediaType.APPLICATION_JSON_VALUE);

--- a/student/src/main/java/tds/student/web/TestManager.java
+++ b/student/src/main/java/tds/student/web/TestManager.java
@@ -20,11 +20,13 @@ import tds.student.services.data.TestOpportunity;
 import AIR.Common.Utilities.SpringApplicationContext;
 import TDS.Shared.Exceptions.ReturnStatusException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
 
 /**
  * @author temp_rreddy
  * 
  */
+
 public class TestManager
 {
   private final TestOpportunity _testOpp;
@@ -38,6 +40,22 @@ public class TestManager
     _testOpp = testOpp;
     _responseService = SpringApplicationContext.getBean ("integrationResponseService", IResponseService.class);
     _adaptiveService = SpringApplicationContext.getBean ("integrationAdaptiveService", IAdaptiveService.class);
+  }
+
+  /**
+   * Constructor to allow passing in dependencies instead of having the {@link tds.student.web.TestManager} wire them
+   * up internally (like the constructor above).
+   *
+   * @param testOpportunity The {@link tds.student.services.data.TestOpportunity} being managed
+   * @param responseService An implementation of the {@link tds.student.services.abstractions.IResponseService}
+   * @param adaptiveService An implementation of the {@link tds.student.services.abstractions.IAdaptiveService}
+   */
+  public TestManager(final TestOpportunity testOpportunity,
+                     final IResponseService responseService,
+                     final IAdaptiveService adaptiveService) {
+    _testOpp = testOpportunity;
+    _responseService = responseService;
+    _adaptiveService = adaptiveService;
   }
 
   private PageList         _pageList     = null;

--- a/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
@@ -32,6 +32,7 @@ import org.springframework.web.util.HtmlUtils;
 import tds.blackbox.web.handlers.TDSHandler;
 import tds.itemrenderer.data.AccLookup;
 import tds.itemrenderer.data.AccProperties;
+import tds.student.services.ReviewTestService;
 import tds.student.services.abstractions.IOpportunityService;
 import tds.student.services.abstractions.IResponseService;
 import tds.student.services.abstractions.PrintService;
@@ -58,6 +59,7 @@ import tds.student.web.data.TestShellAudit;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.ws.Response;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -91,10 +93,13 @@ public class TestShellHandler extends TDSHandler
   private ITDSLogger             _tdsLogger;
 
   private final RemoteExamineeNoteService remoteExamineeNoteService;
+  private final ReviewTestService reviewTestService;
 
   @Autowired
-  public TestShellHandler(final RemoteExamineeNoteService remoteExamineeNoteService) {
+  public TestShellHandler(final RemoteExamineeNoteService remoteExamineeNoteService,
+                          final ReviewTestService reviewTestService) {
     this.remoteExamineeNoteService = remoteExamineeNoteService;
+    this.reviewTestService = reviewTestService;
   }
 
   @RequestMapping (value = "TestShell.axd/logAuditTrail")
@@ -231,31 +236,7 @@ public class TestShellHandler extends TDSHandler
 
     TestOpportunity testOpp = StudentContext.getTestOpportunity ();
 
-    // get responses
-    TestManager testManager = new TestManager (testOpp);
-    testManager.LoadResponses (true);
-
-    // check if test length is met
-    testManager.CheckIfTestComplete ();
-
-    if (!testManager.IsTestLengthMet ()) {
-      // TODO mpatel - Check to see status and message in response and make sure
-      // following works
-      String message = "Review Test: Cannot end test because test length is not met.";
-      _tdsLogger.applicationError (message, "reviewTest", request, null);
-      HttpContext.getCurrentContext ().getResponse ().sendError (HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
-      return null;
-    }
-
-    // check if all visible pages are completed
-    PageList pageList = testManager.GetVisiblePages ();
-
-    if (!pageList.isAllCompleted ()) {
-      String message = "Review Test: Cannot end test because all the groups have not been answered.";
-      _tdsLogger.applicationError (message, "reviewTest", request, null);
-      HttpContext.getCurrentContext ().getResponse ().sendError (HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
-      return null;
-    }
+    ResponseData<String> responseData = reviewTestService.reviewTest(testOpp, request);
 
     String latencies = parseOutLatencies (formParams);
     if (latencies != null) {
@@ -268,12 +249,8 @@ public class TestShellHandler extends TDSHandler
       }
       PerformTestShellAudit (testOpp, testShellAudit, request);
     }
-    // put test in review mode
-    OpportunityStatusChange statusChange = new OpportunityStatusChange (OpportunityStatusType.Review, true);
-    _oppService.setStatus (testOpp.getOppInstance (), statusChange);
 
-    // success
-    return new ResponseData<String> (TDSReplyCode.OK.getCode (), "OK", null);
+    return responseData;
   }
 
   /**

--- a/student/src/test/java/tds/student/services/ReviewTestServiceTest.java
+++ b/student/src/test/java/tds/student/services/ReviewTestServiceTest.java
@@ -1,0 +1,194 @@
+package tds.student.services;
+
+import AIR.Common.Web.TDSReplyCode;
+import AIR.Common.data.ResponseData;
+import TDS.Shared.Exceptions.ReturnStatusException;
+import com.google.common.base.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import tds.common.ValidationError;
+import tds.student.services.abstractions.IAdaptiveService;
+import tds.student.services.abstractions.IOpportunityService;
+import tds.student.services.abstractions.IResponseService;
+import tds.student.services.data.PageList;
+import tds.student.services.data.TestOpportunity;
+import tds.student.sql.data.OpportunityInstance;
+import tds.student.sql.data.TestConfig;
+import tds.student.sql.repository.remote.ExamRepository;
+import tds.student.web.TestManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReviewTestServiceTest {
+    @Mock
+    private IResponseService mockResposneService;
+
+    @Mock
+    private IAdaptiveService mockAdaptiveService;
+
+    @Mock
+    private IOpportunityService mockOpportunityService;
+
+    @Mock
+    private ExamRepository remoteExamRepository;
+
+    private OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "exam-client-name",
+        "browser-agent");
+
+    private TestOpportunity testOpportunity = new TestOpportunity(opportunityInstance,
+        "test-key",
+        "test-id",
+        "language",
+        new TestConfig());
+
+    @Mock
+    private TestManager mockTestManager = new TestManager(testOpportunity,
+        mockResposneService,
+        mockAdaptiveService);
+
+    @Mock
+    private PageList mockPageList = new PageList();
+
+    private ReviewTestService reviewTestService;
+
+    @Before
+    public void setUp() {
+        reviewTestService = new ReviewTestServiceImpl(mockOpportunityService,
+            remoteExamRepository,
+            true,
+            true);
+    }
+
+    @Test
+    public void shouldReviewATestWhenLegacyCallsAndRemoteCallsAreEnabled() throws ReturnStatusException {
+        doNothing().when(mockTestManager).LoadResponses(anyBoolean());
+        when(mockTestManager.GetVisiblePages()).thenReturn(mockPageList);
+        when(mockTestManager.CheckIfTestComplete()).thenReturn(true);
+        when(mockTestManager.IsTestLengthMet()).thenReturn(true);
+        when(mockPageList.isAllCompleted()).thenReturn(true);
+        when(remoteExamRepository.updateStatus(any(UUID.class), anyString(), anyString()))
+            .thenReturn(Optional.<ValidationError>absent());
+
+        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        verify(mockTestManager).LoadResponses(anyBoolean());
+        verify(mockTestManager).GetVisiblePages();
+        verify(mockTestManager).CheckIfTestComplete();
+        verify(mockTestManager).IsTestLengthMet();
+        verify(mockPageList).isAllCompleted();
+        verify(remoteExamRepository).updateStatus(any(UUID.class), anyString(), anyString());
+
+        assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.OK.getCode());
+        assertThat(responseData.getData()).isNull();
+        assertThat(responseData.getReplyText()).isEqualTo("OK");
+    }
+
+    @Test
+    public void shouldReviewATestWhenLegacyCallsAreEnabledButRemoteCallsAreDisabled() throws ReturnStatusException {
+        reviewTestService = new ReviewTestServiceImpl(mockOpportunityService,
+            remoteExamRepository,
+            true,
+            false);
+
+        doNothing().when(mockTestManager).LoadResponses(anyBoolean());
+        when(mockTestManager.GetVisiblePages()).thenReturn(mockPageList);
+        when(mockTestManager.CheckIfTestComplete()).thenReturn(true);
+        when(mockTestManager.IsTestLengthMet()).thenReturn(true);
+        when(mockPageList.isAllCompleted()).thenReturn(true);
+        when(remoteExamRepository.updateStatus(any(UUID.class), anyString(), anyString()))
+            .thenReturn(Optional.<ValidationError>absent());
+
+        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        verify(mockTestManager).LoadResponses(anyBoolean());
+        verify(mockTestManager).GetVisiblePages();
+        verify(mockTestManager).CheckIfTestComplete();
+        verify(mockTestManager).IsTestLengthMet();
+        verify(mockPageList).isAllCompleted();
+        verifyZeroInteractions(remoteExamRepository);
+
+        assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.OK.getCode());
+        assertThat(responseData.getData()).isNull();
+        assertThat(responseData.getReplyText()).isEqualTo("OK");
+    }
+
+    @Test
+    public void ShouldReviewATestWhenLegacyCallsAreDisabledButRemoteCallsAreEnabled() throws ReturnStatusException {
+        reviewTestService = new ReviewTestServiceImpl(mockOpportunityService,
+            remoteExamRepository,
+            false,
+            true);
+
+        doNothing().when(mockTestManager).LoadResponses(anyBoolean());
+        when(mockTestManager.GetVisiblePages()).thenReturn(mockPageList);
+        when(mockTestManager.CheckIfTestComplete()).thenReturn(true);
+        when(mockTestManager.IsTestLengthMet()).thenReturn(true);
+        when(mockPageList.isAllCompleted()).thenReturn(true);
+        when(remoteExamRepository.updateStatus(any(UUID.class), anyString(), anyString()))
+            .thenReturn(Optional.<ValidationError>absent());
+
+        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+
+        // Since the ReviewTestServiceImpl#legacyReviewTest method is private, we can verify that the legacy entities
+        // are not being interacted with.
+        verify(remoteExamRepository).updateStatus(any(UUID.class), anyString(), anyString());
+        verifyZeroInteractions(mockTestManager);
+        verifyZeroInteractions(mockPageList);
+
+        assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.OK.getCode());
+        assertThat(responseData.getData()).isNull();
+        assertThat(responseData.getReplyText()).isEqualTo("OK");
+    }
+
+    @Test
+    public void shouldReturnTestLengthNotMetMessageWhenLegacyCallsAreEnabledAndIsTestLengthMetIsFalse() throws ReturnStatusException {
+        doNothing().when(mockTestManager).LoadResponses(anyBoolean());
+        when(mockTestManager.GetVisiblePages()).thenReturn(mockPageList);
+        when(mockTestManager.CheckIfTestComplete()).thenReturn(true);
+        when(mockTestManager.IsTestLengthMet()).thenReturn(false);
+        when(mockPageList.isAllCompleted()).thenReturn(true);
+        when(remoteExamRepository.updateStatus(any(UUID.class), anyString(), anyString()))
+            .thenReturn(Optional.<ValidationError>absent());
+
+        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+
+        assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.Error.getCode());
+        assertThat(responseData.getData()).isNull();
+        assertThat(responseData.getReplyText()).isEqualTo("Review Test: Cannot end test because test length is not met.");
+    }
+
+    @Test
+    public void shouldReturnGroupsNotAnsweredMessageWhenLegacyCallsAreEnabledAndIsAllCompletedIsFalse() throws ReturnStatusException {
+        doNothing().when(mockTestManager).LoadResponses(anyBoolean());
+        when(mockTestManager.GetVisiblePages()).thenReturn(mockPageList);
+        when(mockTestManager.CheckIfTestComplete()).thenReturn(true);
+        when(mockTestManager.IsTestLengthMet()).thenReturn(true);
+        when(mockPageList.isAllCompleted()).thenReturn(false);
+        when(remoteExamRepository.updateStatus(any(UUID.class), anyString(), anyString()))
+            .thenReturn(Optional.<ValidationError>absent());
+
+        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+
+        assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.Error.getCode());
+        assertThat(responseData.getData()).isNull();
+        assertThat(responseData.getReplyText()).isEqualTo("Review Test: Cannot end test because all the groups have not been answered.");
+    }
+}
+

--- a/student/src/test/java/tds/student/sql/repository/remote/RemoteExamRepositoryTest.java
+++ b/student/src/test/java/tds/student/sql/repository/remote/RemoteExamRepositoryTest.java
@@ -297,51 +297,51 @@ public class RemoteExamRepositoryTest {
     remoteExamRepository.findExamAssessmentInfo(1234, UUID.randomUUID(), "test");
   }
 
-  @Test
-  public void shouldReviewAnExam() throws Exception {
-    final OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        "exam-client",
-        "browser-user-agent");
-
-    doNothing().when(mockRestTemplate).put(isA(URI.class), isNull());
-
-    final Optional<ValidationError> maybeError = remoteExamRepository.reviewExam(opportunityInstance);
-
-    verify(mockRestTemplate).put(isA(URI.class), isNull());
-
-    assertThat(maybeError.isPresent()).isFalse();
-  }
-
-  @Test
-  public void shouldReturnValidationErrorWhenExamIsNotComplete() throws Exception {
-    final OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        UUID.randomUUID(),
-        "exam-client",
-        "browser-user-agent");
-    final String error = "{\n" +
-        "  \"code\": \"examIncomplete\",\n" +
-        "  \"message\": \"Review Test: Cannot end test because test length is not met.\"\n" +
-        "}";
-    final HttpClientErrorException ex = new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY,
-        "Unprocessable Entity",
-        error.getBytes(Charset.defaultCharset()),
-        Charset.defaultCharset());
-
-    doThrow(ex).when(mockRestTemplate).put(isA(URI.class), isNull());
-
-    final Optional<ValidationError> maybeError = remoteExamRepository.reviewExam(opportunityInstance);
-    verify(mockRestTemplate).put(isA(URI.class), isNull());
-
-    assertThat(maybeError.isPresent()).isTrue();
-    ValidationError validationError = maybeError.get();
-    assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.EXAM_INCOMPLETE);
-    assertThat(validationError.getMessage()).isEqualTo("Review Test: Cannot end test because test length is not met.");
-  }
+//  @Test
+//  public void shouldReviewAnExam() throws Exception {
+//    final OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        "exam-client",
+//        "browser-user-agent");
+//
+//    doNothing().when(mockRestTemplate).put(isA(URI.class), isNull());
+//
+//    final Optional<ValidationError> maybeError = remoteExamRepository.reviewExam(opportunityInstance);
+//
+//    verify(mockRestTemplate).put(isA(URI.class), isNull());
+//
+//    assertThat(maybeError.isPresent()).isFalse();
+//  }
+//
+//  @Test
+//  public void shouldReturnValidationErrorWhenExamIsNotComplete() throws Exception {
+//    final OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        UUID.randomUUID(),
+//        "exam-client",
+//        "browser-user-agent");
+//    final String error = "{\n" +
+//        "  \"code\": \"examIncomplete\",\n" +
+//        "  \"message\": \"Review Test: Cannot end test because test length is not met.\"\n" +
+//        "}";
+//    final HttpClientErrorException ex = new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY,
+//        "Unprocessable Entity",
+//        error.getBytes(Charset.defaultCharset()),
+//        Charset.defaultCharset());
+//
+//    doThrow(ex).when(mockRestTemplate).put(isA(URI.class), isNull());
+//
+//    final Optional<ValidationError> maybeError = remoteExamRepository.reviewExam(opportunityInstance);
+//    verify(mockRestTemplate).put(isA(URI.class), isNull());
+//
+//    assertThat(maybeError.isPresent()).isTrue();
+//    ValidationError validationError = maybeError.get();
+//    assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.EXAM_INCOMPLETE);
+//    assertThat(validationError.getMessage()).isEqualTo("Review Test: Cannot end test because test length is not met.");
+//  }
 }

--- a/student/src/test/java/tds/student/sql/repository/remote/RemoteExamRepositoryTest.java
+++ b/student/src/test/java/tds/student/sql/repository/remote/RemoteExamRepositoryTest.java
@@ -19,7 +19,11 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,11 +39,17 @@ import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
 import tds.exam.OpenExamRequest;
 import tds.exam.SegmentApprovalRequest;
+import tds.exam.error.ValidationErrorCode;
+import tds.student.sql.data.OpportunityInstance;
 import tds.student.sql.repository.remote.impl.RemoteExamRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -287,5 +297,51 @@ public class RemoteExamRepositoryTest {
     remoteExamRepository.findExamAssessmentInfo(1234, UUID.randomUUID(), "test");
   }
 
+  @Test
+  public void shouldReviewAnExam() throws Exception {
+    final OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "exam-client",
+        "browser-user-agent");
 
+    doNothing().when(mockRestTemplate).put(isA(URI.class), isNull());
+
+    final Optional<ValidationError> maybeError = remoteExamRepository.reviewExam(opportunityInstance);
+
+    verify(mockRestTemplate).put(isA(URI.class), isNull());
+
+    assertThat(maybeError.isPresent()).isFalse();
+  }
+
+  @Test
+  public void shouldReturnValidationErrorWhenExamIsNotComplete() throws Exception {
+    final OpportunityInstance opportunityInstance = new OpportunityInstance(UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "exam-client",
+        "browser-user-agent");
+    final String error = "{\n" +
+        "  \"code\": \"examIncomplete\",\n" +
+        "  \"message\": \"Review Test: Cannot end test because test length is not met.\"\n" +
+        "}";
+    final HttpClientErrorException ex = new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY,
+        "Unprocessable Entity",
+        error.getBytes(Charset.defaultCharset()),
+        Charset.defaultCharset());
+
+    doThrow(ex).when(mockRestTemplate).put(isA(URI.class), isNull());
+
+    final Optional<ValidationError> maybeError = remoteExamRepository.reviewExam(opportunityInstance);
+    verify(mockRestTemplate).put(isA(URI.class), isNull());
+
+    assertThat(maybeError.isPresent()).isTrue();
+    ValidationError validationError = maybeError.get();
+    assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.EXAM_INCOMPLETE);
+    assertThat(validationError.getMessage()).isEqualTo("Review Test: Cannot end test because test length is not met.");
+  }
 }


### PR DESCRIPTION
[TDS-519](https://jira.fairwaytech.com/browse/TDS-519):  Integration with exam service endpoint for review exam

**NOTE:** This PR depends on [this PR against the **TDS_ExamService**](https://github.com/SmarterApp/TDS_ExamService/pull/170)

**NOTE:** I Could not find a good way to unit test the `ReviewTestService` that was introduced as part of this PR.  Part of the issue is the reliance on the `TestManager` class and the way it gets at its dependencies (using `AIR.Common.Utilities.SpringApplicationContext.getBean()`.  I tried to test the "exam service" side, but also had some wiring issues for dependencies.  In the end, testing was conducted manually which is... disappointing.  If there are any ideas on how to write unit tests for the `ReviewTestService`, I'm certainly willing to listen.