### PR TITLE
Removing unneeded legacy calls in exam submission flow. Renaming Revi…

### DIFF
--- a/student/src/main/java/tds/student/services/ExamCompletionService.java
+++ b/student/src/main/java/tds/student/services/ExamCompletionService.java
@@ -12,7 +12,7 @@ import tds.student.web.TestManager;
 /**
  * A service for verifying an {@link tds.student.services.data.TestOpportunity} can be moved to the "review" status.
  */
-public interface ReviewTestService {
+public interface ExamCompletionService {
     /**
      * Move an {@link tds.exam.Exam} to the "review" status, meaning a student has answered all the questions and is
      * ready to review the questions before submitting the exam for scoring.
@@ -24,7 +24,7 @@ public interface ReviewTestService {
      * @return A {@link AIR.Common.data.ResponseData} indicating success or failure
      * @throws ReturnStatusException In the event of a failure
      */
-    ResponseData<String> reviewTest(final TestOpportunity testOpportunity,
-                                    final TestManager testManager,
-                                    final String statusCode) throws ReturnStatusException;
+    ResponseData<String> updateStatusWithValidation(final TestOpportunity testOpportunity,
+                                                    final TestManager testManager,
+                                                    final String statusCode) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/services/ExamCompletionService.java
+++ b/student/src/main/java/tds/student/services/ExamCompletionService.java
@@ -20,9 +20,11 @@ public interface ReviewTestService {
      * @param testOpportunity The {@link tds.student.services.data.TestOpportunity}
      * @param testManager     The {@link tds.student.web.TestManager} handling the
      *                        {@link tds.student.services.data.TestOpportunity}
+     * @param statusCode      The code of the status to set the Exam to
      * @return A {@link AIR.Common.data.ResponseData} indicating success or failure
      * @throws ReturnStatusException In the event of a failure
      */
     ResponseData<String> reviewTest(final TestOpportunity testOpportunity,
-                                    final TestManager testManager) throws ReturnStatusException;
+                                    final TestManager testManager,
+                                    final String statusCode) throws ReturnStatusException;
 }

--- a/student/src/main/java/tds/student/services/ExamCompletionServiceImpl.java
+++ b/student/src/main/java/tds/student/services/ExamCompletionServiceImpl.java
@@ -39,8 +39,8 @@ public class ExamCompletionServiceImpl implements ExamCompletionService {
 
         this.opportunityService = opportunityService;
         this.examRepository = examRepository;
-        isLegacyCallsEnabled = false;
-        isRemoteCallsEnabled = true;
+        isLegacyCallsEnabled = legacyCallsEnabled;
+        isRemoteCallsEnabled = remoteExamCallsEnabled;
     }
 
     @Override

--- a/student/src/main/java/tds/student/services/ExamCompletionServiceImpl.java
+++ b/student/src/main/java/tds/student/services/ExamCompletionServiceImpl.java
@@ -50,7 +50,7 @@ public class ExamCompletionServiceImpl implements ExamCompletionService {
         ResponseData<String> responseData = new ResponseData<>(TDSReplyCode.OK.getCode(), "OK", null);
 
         if (isLegacyCallsEnabled) {
-            responseData = legacyReviewTest(testOpportunity, testManager, statusCode);
+            responseData = legacyValidateAndUpdateTest(testOpportunity, testManager, statusCode);
         }
 
         if (!isRemoteCallsEnabled) {
@@ -82,9 +82,13 @@ public class ExamCompletionServiceImpl implements ExamCompletionService {
      * @throws ReturnStatusException In the event of a failure from one of the {@link tds.student.web.TestManager}
      *                               methods
      */
-    private ResponseData<String> legacyReviewTest(final TestOpportunity testOpportunity, final TestManager testManager,
-                                                  final String statusCode)
+    private ResponseData<String> legacyValidateAndUpdateTest(final TestOpportunity testOpportunity, final TestManager testManager,
+                                                             final String statusCode)
         throws ReturnStatusException {
+        if (!ExamStatusCode.STATUS_REVIEW.equals(statusCode) && !ExamStatusCode.STATUS_COMPLETED.equals(statusCode)) {
+            throw new IllegalArgumentException("Can only call the legacy method with a status code of 'review' or 'completed'.");
+        }
+
         // get responses
         testManager.LoadResponses(true);
 

--- a/student/src/main/java/tds/student/services/ExamCompletionServiceImpl.java
+++ b/student/src/main/java/tds/student/services/ExamCompletionServiceImpl.java
@@ -22,34 +22,35 @@ import tds.student.web.TestManager;
 
 @Service
 @Scope("prototype")
-public class ReviewTestServiceImpl implements ReviewTestService {
+public class ExamCompletionServiceImpl implements ExamCompletionService {
     private final IOpportunityService opportunityService;
     private final ExamRepository examRepository;
     private final boolean isLegacyCallsEnabled;
     private final boolean isRemoteCallsEnabled;
 
     @Autowired
-    public ReviewTestServiceImpl(@Qualifier("integrationOpportunityService") final IOpportunityService opportunityService,
-                                 final ExamRepository examRepository,
-                                 @Value("${tds.exam.legacy.enabled}") final boolean legacyCallsEnabled,
-                                 @Value("${tds.exam.remote.enabled}") final boolean remoteExamCallsEnabled) {
+    public ExamCompletionServiceImpl(@Qualifier("integrationOpportunityService") final IOpportunityService opportunityService,
+                                     final ExamRepository examRepository,
+                                     @Value("${tds.exam.legacy.enabled}") final boolean legacyCallsEnabled,
+                                     @Value("${tds.exam.remote.enabled}") final boolean remoteExamCallsEnabled) {
         if (!remoteExamCallsEnabled && !legacyCallsEnabled) {
             throw new IllegalStateException("Remote and legacy calls are both disabled.  Please check progman configuration for 'tds.exam.remote.enabled' and 'tds.exam.legacy.enabled' settings");
         }
 
         this.opportunityService = opportunityService;
         this.examRepository = examRepository;
-        isLegacyCallsEnabled = legacyCallsEnabled;
-        isRemoteCallsEnabled = remoteExamCallsEnabled;
+        isLegacyCallsEnabled = false;
+        isRemoteCallsEnabled = true;
     }
 
     @Override
-    public ResponseData<String> reviewTest(final TestOpportunity testOpportunity, final TestManager testManager)
+    public ResponseData<String> updateStatusWithValidation(final TestOpportunity testOpportunity, final TestManager testManager,
+                                                           final String statusCode)
         throws ReturnStatusException {
         ResponseData<String> responseData = new ResponseData<>(TDSReplyCode.OK.getCode(), "OK", null);
 
         if (isLegacyCallsEnabled) {
-            responseData = legacyReviewTest(testOpportunity, testManager);
+            responseData = legacyReviewTest(testOpportunity, testManager, statusCode);
         }
 
         if (!isRemoteCallsEnabled) {
@@ -58,8 +59,9 @@ public class ReviewTestServiceImpl implements ReviewTestService {
 
         final Optional<ValidationError> maybeValidationError =
             examRepository.updateStatus(testOpportunity.getOppInstance().getExamId(),
-                ExamStatusCode.STATUS_REVIEW,
+                statusCode,
                 null);
+
         if (maybeValidationError.isPresent()) {
             return new ResponseData<>(TDSReplyCode.Error.getCode(),
                 maybeValidationError.get().getMessage(),
@@ -80,7 +82,8 @@ public class ReviewTestServiceImpl implements ReviewTestService {
      * @throws ReturnStatusException In the event of a failure from one of the {@link tds.student.web.TestManager}
      *                               methods
      */
-    private ResponseData<String> legacyReviewTest(final TestOpportunity testOpportunity, final TestManager testManager)
+    private ResponseData<String> legacyReviewTest(final TestOpportunity testOpportunity, final TestManager testManager,
+                                                  final String statusCode)
         throws ReturnStatusException {
         // get responses
         testManager.LoadResponses(true);
@@ -103,7 +106,7 @@ public class ReviewTestServiceImpl implements ReviewTestService {
 
         // put test in review mode
         OpportunityStatusChange statusChange =
-            new OpportunityStatusChange(OpportunityStatusType.Review, true);
+            new OpportunityStatusChange(OpportunityStatusType.parse(statusCode), true);
         opportunityService.setStatus(testOpportunity.getOppInstance(), statusChange);
 
         return new ResponseData<>(TDSReplyCode.OK.getCode(), "OK", null);

--- a/student/src/main/java/tds/student/web/handlers/MasterShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/MasterShellHandler.java
@@ -657,6 +657,11 @@ public class MasterShellHandler extends TDSHandler
   public ResponseData<TestSummary> scoreTest (HttpServletRequest request) throws ReturnStatusException, TDSSecurityException, StudentContextException {
     checkAuthenticated ();
     TestOpportunity testOpp = StudentContext.getTestOpportunity ();
+    // validate context
+    if (testOpp == null) {
+      StudentContext.throwMissingException();
+    }
+    
     examCompletionService.updateStatusWithValidation(testOpp, new TestManager(testOpp), ExamStatusCode.STATUS_COMPLETED);
     // Send the exam status to ART
     sendTestStatus (StudentContext.getTestee ().getId (), testOpp.getTestKey (), testOpp.getOppInstance ().getKey (), TestStatusType.COMPLETED);

--- a/student/src/main/java/tds/student/web/handlers/MasterShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/MasterShellHandler.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import tds.blackbox.web.handlers.TDSHandler;
+import tds.exam.ExamStatusCode;
 import tds.itemrenderer.data.AccLookup;
 import tds.itemrenderer.data.AccProperties;
 import tds.student.data.Segment;
@@ -59,6 +60,7 @@ import tds.student.performance.services.ItemBankService;
 import tds.student.proxy.data.Proctor;
 import tds.student.sbacossmerge.data.GeoComponent;
 import tds.student.sbacossmerge.data.GeoType;
+import tds.student.services.ExamCompletionService;
 import tds.student.services.abstractions.IAccommodationsService;
 import tds.student.services.abstractions.ILoginService;
 import tds.student.services.abstractions.IOpportunityService;
@@ -69,7 +71,6 @@ import tds.student.services.data.ApprovalInfo;
 import tds.student.services.data.ApprovalInfo.OpportunityApprovalStatus;
 import tds.student.services.data.LoginInfo;
 import tds.student.services.data.LoginKeyValues;
-import tds.student.services.data.PageList;
 import tds.student.services.data.TestOpportunity;
 import tds.student.services.data.TestScoreStatus;
 import tds.student.sql.abstractions.IOpportunityRepository;
@@ -147,6 +148,9 @@ public class MasterShellHandler extends TDSHandler
   @Autowired
   @Qualifier("integrationOpportunityService")
   private IOpportunityService    _oppService;
+
+  @Autowired
+  private ExamCompletionService examCompletionService;
 
   /***
    * 
@@ -499,8 +503,6 @@ public class MasterShellHandler extends TDSHandler
     StudentContext.saveTestConfig (testConfig);
     StudentCookie.writeStore ();
     sendTestStatus (StudentContext.getTestee ().getId (), testKey, oppInstance.getKey (), TestStatusType.STARTED);
-    // log browser info
-    //TODO: Remove this call when we are ready to disable legacy calls
 //    logBrowser (oppInstance, testConfig.getRestart ());
     TestInfo testInfo = loadTestInfo (oppInstance, testConfig);
 
@@ -654,54 +656,12 @@ public class MasterShellHandler extends TDSHandler
   @ResponseBody
   public ResponseData<TestSummary> scoreTest (HttpServletRequest request) throws ReturnStatusException, TDSSecurityException, StudentContextException {
     checkAuthenticated ();
-
     TestOpportunity testOpp = StudentContext.getTestOpportunity ();
-
-    // validate context
-    if (testOpp == null)
-      StudentContext.throwMissingException ();
-
-    TestManager testManager = new TestManager (testOpp);
-    testManager.LoadResponses (true);
-
-    // If there are more adaptive item groups to take then stop here and
-    // return
-    testManager.CheckIfTestComplete ();
-
-    if (!testManager.IsTestLengthMet ()) {
-      String message = "Review: A student has tried to complete the test but there are still more items left to be generated.";
-      _tdsLogger.applicationError (message, "scoreTest", request, null);
-      HttpContext.getCurrentContext ().getResponse ().setStatus (HttpStatus.SC_FORBIDDEN);
-      return new ResponseData<TestSummary> (TDSReplyCode.Denied.getCode (), message, null);
-    }
-
-    // check if all visible pages are completed
-    PageList pages = testManager.GetVisiblePages ();
-
-    if (!pages.isAllCompleted ()) {
-      String message = "Review: A student has tried to complete the test but all the questions are not completed.";
-      _tdsLogger.applicationError (message, "scoreTest", request, null);
-      HttpContext.getCurrentContext ().getResponse ().setStatus (HttpStatus.SC_FORBIDDEN);
-      return new ResponseData<TestSummary> (TDSReplyCode.Denied.getCode (), message, null);
-    }
-
-    // complete test
-    _oppService.setStatus (testOpp.getOppInstance (), new OpportunityStatusChange (OpportunityStatusType.Completed, true));
-
+    examCompletionService.updateStatusWithValidation(testOpp, new TestManager(testOpp), ExamStatusCode.STATUS_COMPLETED);
+    // Send the exam status to ART
     sendTestStatus (StudentContext.getTestee ().getId (), testOpp.getTestKey (), testOpp.getOppInstance ().getKey (), TestStatusType.COMPLETED);
 
-    // score the test
-    TestScoreStatus scoreStatus = _testScoringService.scoreTest (testOpp.getOppInstance ().getKey (), testOpp.getTestKey ());
-
-    // if we successfully scored the record the server latency
-    if (scoreStatus == TestScoreStatus.Submitted) {
-      ServerLatency latency = ServerLatency.getCurrent (HttpContext.getCurrentContext ());
-      latency.setOperation (ServerLatency.OperationType.Score);
-    }
-
-    // try and get scores
-    return getTestSummary ();
-
+    return new ResponseData<TestSummary> (TDSReplyCode.OK.getCode (), "OK", new TestSummary());
   }
 
   /***

--- a/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
+++ b/student/src/main/java/tds/student/web/handlers/TestShellHandler.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Educational Online Test Delivery System Copyright (c) 2014 American
  * Institutes for Research
- * 
+ *
  * Distributed under the AIR Open Source License, Version 1.0 See accompanying
  * file AIR-License-1_0.txt or at http://www.smarterapp.org/documents/
  * American_Institutes_for_Research_Open_Source_Software_License.pdf
@@ -30,9 +30,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.util.HtmlUtils;
 import tds.blackbox.web.handlers.TDSHandler;
+import tds.exam.ExamStatusCode;
 import tds.itemrenderer.data.AccLookup;
 import tds.itemrenderer.data.AccProperties;
-import tds.student.services.ReviewTestService;
+import tds.student.services.ExamCompletionService;
 import tds.student.services.abstractions.IOpportunityService;
 import tds.student.services.abstractions.IResponseService;
 import tds.student.services.abstractions.PrintService;
@@ -40,7 +41,6 @@ import tds.student.services.data.ApprovalInfo;
 import tds.student.services.data.ApprovalInfo.OpportunityApprovalStatus;
 import tds.student.services.data.ItemResponse;
 import tds.student.services.data.PageGroup;
-import tds.student.services.data.PageList;
 import tds.student.services.data.TestOpportunity;
 import tds.student.services.remote.RemoteExamineeNoteService;
 import tds.student.sql.abstractions.IOpportunityRepository;
@@ -59,7 +59,6 @@ import tds.student.web.data.TestShellAudit;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.xml.ws.Response;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +67,7 @@ import java.util.UUID;
 
 /**
  * @author mpatel
- * 
+ *
  */
 @Controller
 @Scope ("prototype")
@@ -93,13 +92,13 @@ public class TestShellHandler extends TDSHandler
   private ITDSLogger             _tdsLogger;
 
   private final RemoteExamineeNoteService remoteExamineeNoteService;
-  private final ReviewTestService reviewTestService;
+  private final ExamCompletionService examCompletionService;
 
   @Autowired
   public TestShellHandler(final RemoteExamineeNoteService remoteExamineeNoteService,
-                          final ReviewTestService reviewTestService) {
+                          final ExamCompletionService examCompletionService) {
     this.remoteExamineeNoteService = remoteExamineeNoteService;
-    this.reviewTestService = reviewTestService;
+    this.examCompletionService = examCompletionService;
   }
 
   @RequestMapping (value = "TestShell.axd/logAuditTrail")
@@ -237,13 +236,14 @@ public class TestShellHandler extends TDSHandler
 
     TestOpportunity testOpp = StudentContext.getTestOpportunity ();
 
-    ResponseData<String> responseData = reviewTestService.reviewTest(testOpp, new TestManager(testOpp));
+    ResponseData<String> responseData = examCompletionService.updateStatusWithValidation(testOpp, new TestManager(testOpp),
+      ExamStatusCode.STATUS_REVIEW);
 
     if (responseData.getReplyCode() != TDSReplyCode.OK.getCode()) {
-      _tdsLogger.applicationError (responseData.getReplyText(), "reviewTest", request, null);
+      _tdsLogger.applicationError (responseData.getReplyText(), "updateStatusWithValidation", request, null);
       HttpContext.getCurrentContext()
-          .getResponse()
-          .sendError(HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
+        .getResponse()
+        .sendError(HttpStatus.SC_FORBIDDEN, "Cannot end the test.");
 
       return null;
     }
@@ -253,7 +253,7 @@ public class TestShellHandler extends TDSHandler
 
   /**
    * Gets the test shell audit json and logs data to the DB.
-   * 
+   *
    * @param testOpp
    * @throws ReturnStatusException
    */

--- a/student/src/test/java/tds/student/services/ExamCompletionServiceTest.java
+++ b/student/src/test/java/tds/student/services/ExamCompletionServiceTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ReviewTestServiceTest {
+public class ExamCompletionServiceTest {
     @Mock
     private IResponseService mockResposneService;
 
@@ -65,11 +65,11 @@ public class ReviewTestServiceTest {
     @Mock
     private PageList mockPageList = new PageList();
 
-    private ReviewTestService reviewTestService;
+    private ExamCompletionService examCompletionService;
 
     @Before
     public void setUp() {
-        reviewTestService = new ReviewTestServiceImpl(mockOpportunityService,
+        examCompletionService = new ExamCompletionServiceImpl(mockOpportunityService,
             remoteExamRepository,
             true,
             true);
@@ -85,7 +85,7 @@ public class ReviewTestServiceTest {
         when(remoteExamRepository.updateStatus(opportunityInstance.getExamId(), "review", null))
             .thenReturn(Optional.<ValidationError>absent());
 
-        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        final ResponseData<String> responseData = examCompletionService.updateStatusWithValidation(testOpportunity, mockTestManager, "review");
         verify(mockTestManager).LoadResponses(true);
         verify(mockTestManager).GetVisiblePages();
         verify(mockTestManager).CheckIfTestComplete();
@@ -100,7 +100,7 @@ public class ReviewTestServiceTest {
 
     @Test
     public void shouldReviewATestWhenLegacyCallsAreEnabledButRemoteCallsAreDisabled() throws ReturnStatusException {
-        reviewTestService = new ReviewTestServiceImpl(mockOpportunityService,
+        examCompletionService = new ExamCompletionServiceImpl(mockOpportunityService,
             remoteExamRepository,
             true,
             false);
@@ -113,7 +113,7 @@ public class ReviewTestServiceTest {
         when(remoteExamRepository.updateStatus(opportunityInstance.getExamId(), "review", null))
             .thenReturn(Optional.<ValidationError>absent());
 
-        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        final ResponseData<String> responseData = examCompletionService.updateStatusWithValidation(testOpportunity, mockTestManager, "review");
         verify(mockTestManager).LoadResponses(true);
         verify(mockTestManager).GetVisiblePages();
         verify(mockTestManager).CheckIfTestComplete();
@@ -128,7 +128,7 @@ public class ReviewTestServiceTest {
 
     @Test
     public void ShouldReviewATestWhenLegacyCallsAreDisabledButRemoteCallsAreEnabled() throws ReturnStatusException {
-        reviewTestService = new ReviewTestServiceImpl(mockOpportunityService,
+        examCompletionService = new ExamCompletionServiceImpl(mockOpportunityService,
             remoteExamRepository,
             false,
             true);
@@ -141,9 +141,9 @@ public class ReviewTestServiceTest {
         when(remoteExamRepository.updateStatus(opportunityInstance.getExamId(), "review", null))
             .thenReturn(Optional.<ValidationError>absent());
 
-        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        final ResponseData<String> responseData = examCompletionService.updateStatusWithValidation(testOpportunity, mockTestManager, "review");
 
-        // Since the ReviewTestServiceImpl#legacyReviewTest method is private, we can verify that the legacy entities
+        // Since the ExamCompletionServiceImpl#legacyReviewTest method is private, we can verify that the legacy entities
         // are not being interacted with.
         verify(remoteExamRepository).updateStatus(opportunityInstance.getExamId(), "review", null);
         verifyZeroInteractions(mockTestManager);
@@ -164,7 +164,7 @@ public class ReviewTestServiceTest {
         when(remoteExamRepository.updateStatus(opportunityInstance.getExamId(), "review", null))
             .thenReturn(Optional.<ValidationError>absent());
 
-        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        final ResponseData<String> responseData = examCompletionService.updateStatusWithValidation(testOpportunity, mockTestManager, "review");
 
         assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.Error.getCode());
         assertThat(responseData.getData()).isNull();
@@ -181,7 +181,7 @@ public class ReviewTestServiceTest {
         when(remoteExamRepository.updateStatus(opportunityInstance.getExamId(), "review", null))
             .thenReturn(Optional.<ValidationError>absent());
 
-        final ResponseData<String> responseData = reviewTestService.reviewTest(testOpportunity, mockTestManager);
+        final ResponseData<String> responseData = examCompletionService.updateStatusWithValidation(testOpportunity, mockTestManager, "review");
 
         assertThat(responseData.getReplyCode()).isEqualTo(TDSReplyCode.Error.getCode());
         assertThat(responseData.getData()).isNull();


### PR DESCRIPTION
…ewService to something more generic, since this update call is used by both /review and /submit flow.

A lot of logic has been removed to MasterShellHandler. This is either because it is already handled within ExamService, or because it is not a needed feature (TDS scoring, saving "server latency"). See comments below.