### PR TITLE
TDS-1189: Remove hard-coding width from additional locations

### DIFF
--- a/student/src/main/webapp/Shared/CSS/Modern/items.css
+++ b/student/src/main/webapp/Shared/CSS/Modern/items.css
@@ -820,19 +820,15 @@ a.guideToRevision:hover, a.guideToRevision:focus, .TDS_PS_L1 a.guideToRevision:h
 }
 .TDS_PS_L1 #wordListPanel {
 	font-size: 1.25em;
-	width: 400px !important;
 }
 .TDS_PS_L2 #wordListPanel {
 	font-size: 1.5em;
-	width: 480px !important;
 }
 .TDS_PS_L3 #wordListPanel {
 	font-size: 1.75em;
-	width: 560px !important;
 }
 .TDS_PS_L4 #wordListPanel {
 	font-size: 2em;
-	width: 640px !important;
 }
 /* adjusting line height to prevent borders from overlapping */
 .TDS_WORD_LIST, .TDS_WORD_LIST_HOVER, .TDS_WORD_LIST:hover {

--- a/student/src/main/webapp/Shared/CSS/Universal/items.css
+++ b/student/src/main/webapp/Shared/CSS/Universal/items.css
@@ -943,6 +943,7 @@ div.toolsContainer a.itemMenu {
 	font-size: .9em;
 	font-weight: normal;
 	border-bottom: solid 1px #00aeef;
+	overflow: hidden;
 }
 #wordListPanel .yui-nav a {
 	padding: .2em;
@@ -1009,19 +1010,15 @@ div.toolsContainer a.itemMenu {
 }
 .TDS_PS_L1 #wordListPanel {
 	font-size: 1.25em;
-	width: 400px !important;
 }
 .TDS_PS_L2 #wordListPanel {
 	font-size: 1.5em;
-	width: 480px !important;
 }
 .TDS_PS_L3 #wordListPanel {
 	font-size: 1.75em;
-	width: 560px !important;
 }
 .TDS_PS_L4 #wordListPanel {
 	font-size: 2em;
-	width: 640px !important;
 }
 /* adjusting line height to prevent borders from overlapping */
 .TDS_WORD_LIST,

--- a/student/src/main/webapp/Shared/CSS/dialogs.css
+++ b/student/src/main/webapp/Shared/CSS/dialogs.css
@@ -62,7 +62,6 @@
 	-webkit-border-radius: 10px;
 	border-radius: 10px;
 	background-color: #fff;
-	width: 500px;
 }
 .browserVer_2.browser_firefox.yui-skin-sam .yui-panel, .browserVer_3.browser_firefox.yui-skin-sam .yui-panel {
 	border-color: #ccc;


### PR DESCRIPTION
[TDS-1189](https://jira.fairwaytech.com/browse/TDS-1189):  The width of the illustration glossary was also enforced (with an `!important`) at each zoom level.  Also noticed that sometimes the verbiage would extend past the boundaries of the modal window.  Took the following action:

* Removed the `width: [size in pixels] !important;` from each zoom-level class
* Added `overflow: hidden;` to prevent the "header" text directly above the image from extending beyond the width of the modal