### PR TITLE
Fixing  "disable for guest" filter for test tools when taking a practice test

### DIFF
--- a/student/src/main/java/tds/student/services/AccommodationsService.java
+++ b/student/src/main/java/tds/student/services/AccommodationsService.java
@@ -396,13 +396,9 @@ public class AccommodationsService implements IAccommodationsService
     AccList accList = itemBankService.getTestAccommodations (testProps.getTestKey ());
     // if this is PT then remove all acc's that are disabled for guest sessions
     try {
-      if (isGuestSession)
-        CollectionUtils.removeAll (accList.getData(), CollectionUtils.select (accList.getData(), new Predicate ()
-        {
-          public boolean evaluate (Object object) {
-            return ((Data) object).isDisableOnGuestSession ();
-          }
-        }));
+      if (isGuestSession) {
+        accList.getData().removeAll(CollectionUtils.select(accList.getData(), object -> ((Data) object).isDisableOnGuestSession()));
+      }
       // first create the test accommodations
       Accommodations testAccs = null;
       testAccs = accList.createAccommodations (0, testProps.getTestID (), testProps.getDisplayName ());


### PR DESCRIPTION
This bug is the cause of https://jira.fairwaytech.com/browse/TDS-1239 - tools that should be filtered from practice test are making it through, and the client-side code is not properly disabling the select boxes in the "Is This Your Test?" page.

`CollectionUtils.removeAll()` was broken in 3.2.1 - see (https://stackoverflow.com/questions/8372576/java-commons-collections-removeall) - This method was calling `CollectionUtils.retainAll()` internally. In 4.1, this method was updated to return this list of items from the collection that should be removed. The existing code does seems to call `removeAll()` with the intension of mutating the accommodations list passed in as the first argument.
