### PR TITLE
Release of 4.0.3.RELEASE

### DIFF
--- a/SpellCheck/pom.xml
+++ b/SpellCheck/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>student-parent</artifactId>
-		<version>4.0.3.RELEASE</version>
+		<version>4.0.4-SNAPSHOT</version>
 	</parent>
 
   	<licenses>

--- a/SpellCheck/pom.xml
+++ b/SpellCheck/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>student-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.0.3.RELEASE</version>
 	</parent>
 
   	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.8</item-renderer.version>
+        <item-renderer.version>4.0.7.RELEASE</item-renderer.version>
         <item-selection.version>4.0.3.RELEASE</item-selection.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <tds-dll.version>4.0.3.RELEASE</tds-dll.version>
         <test-scoring.version>3.1.1.RELEASE</test-scoring.version>
-        <tds-student-common.version>4.0.5</tds-student-common.version>
+        <tds-student-common.version>4.0.6.RELEASE</tds-student-common.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>student-parent</artifactId>
     <name>student-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.3-SNAPSHOT</version>
+    <version>4.0.3.RELEASE</version>
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
@@ -148,7 +148,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_Student.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_Student.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_Student</url>
-        <tag>HEAD</tag>
+        <tag>4.0.3.RELEASE</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>student-parent</artifactId>
     <name>student-parent</name>
     <packaging>pom</packaging>
-    <version>4.0.3.RELEASE</version>
+    <version>4.0.4-SNAPSHOT</version>
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
@@ -148,7 +148,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_Student.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_Student.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_Student</url>
-        <tag>4.0.3.RELEASE</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.8<8<8<8<8<8<8<8</item-renderer.version>
+        <item-renderer.version>4.0.8</item-renderer.version>
         <item-selection.version>4.0.3.RELEASE</item-selection.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.7.RELEASE</item-renderer.version>
+        <item-renderer.version>4.0.8<8<8<8<8<8<8<8</item-renderer.version>
         <item-selection.version>4.0.3.RELEASE</item-selection.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>

--- a/student/pom.xml
+++ b/student/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 		<progman-client.version>4.0.5.RELEASE</progman-client.version>
 		<sb11-mna-client.version>4.0.3.RELEASE</sb11-mna-client.version>
-		<tds-exam-client.version>4.0.3</tds-exam-client.version>
+		<tds-exam-client.version>4.0.6.RELEASE</tds-exam-client.version>
 		<sb11-shared-code.version>4.0.6.RELEASE</sb11-shared-code.version>
 		<tds-common-legacy.version>4.0.1.RELEASE</tds-common-legacy.version>
 		<tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>

--- a/student/pom.xml
+++ b/student/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>student-parent</artifactId>
-		<version>4.0.3.RELEASE</version>
+		<version>4.0.4-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>student</artifactId>

--- a/student/pom.xml
+++ b/student/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.opentestsystem.delivery</groupId>
 		<artifactId>student-parent</artifactId>
-		<version>4.0.3-SNAPSHOT</version>
+		<version>4.0.3.RELEASE</version>
 	</parent>
 
 	<artifactId>student</artifactId>


### PR DESCRIPTION
Merge 4.0.3.RELEASE into `develop`.  This PR:
* updates the `tds-student-common` release to 4.0.6.RELASE (the latest version)
* leaves the `item-renderer` version at 4.0.8, which is the current version being developed against.
  * the 4.0.3.RELEASE tag of `TDS_Student` has the `item-renderer` version set to 4.0.7.RELEASE, which is the latest released version