### PR TITLE
remove fix focus api call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>4.0.11</item-renderer.version>
+        <item-renderer.version>4.0.12</item-renderer.version>
         <item-selection.version>4.0.3.RELEASE</item-selection.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
secure browser 10 does not have the "fixFocus" api that was used to workaround an older secure browser ui bug.