### PR TITLE
TDS-1449: add allAnswered to test response writer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>5.0.0.RELEASE</item-renderer.version>
+        <item-renderer.version>5.0.1-SNAPSHOT</item-renderer.version>
         <item-selection.version>4.0.3.RELEASE</item-selection.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <tds-dll.version>4.0.3.RELEASE</tds-dll.version>
         <test-scoring.version>3.1.1.RELEASE</test-scoring.version>
-        <tds-student-common.version>4.0.6.RELEASE</tds-student-common.version>
+        <tds-student-common.version>4.0.7-SNAPSHOT</tds-student-common.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,14 @@
 
     <properties>
         <assertj.version>2.6.0</assertj.version>
-        <item-renderer.version>5.0.1-SNAPSHOT</item-renderer.version>
+        <item-renderer.version>5.0.1.RELEASE</item-renderer.version>
         <item-selection.version>4.0.3.RELEASE</item-selection.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <tds-dll.version>4.0.3.RELEASE</tds-dll.version>
         <test-scoring.version>3.1.1.RELEASE</test-scoring.version>
-        <tds-student-common.version>4.0.7-SNAPSHOT</tds-student-common.version>
+        <tds-student-common.version>4.0.7.RELEASE</tds-student-common.version>
     </properties>
 
     <modules>

--- a/student/src/main/java/tds/student/web/handlers/TestResponseWriter.java
+++ b/student/src/main/java/tds/student/web/handlers/TestResponseWriter.java
@@ -8,15 +8,15 @@
  ******************************************************************************/
 package tds.student.web.handlers;
 
-import java.io.OutputStream;
-import java.util.List;
-import java.util.UUID;
+import AIR.Common.Web.Session.HttpContext;
+import AIR.Common.xml.TdsXmlOutputFactory;
 
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
-import org.apache.commons.lang3.StringUtils;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.UUID;
 
 import tds.student.services.data.ItemResponse;
 import tds.student.services.data.PageGroup;
@@ -24,8 +24,6 @@ import tds.student.services.data.PageList;
 import tds.student.services.data.TestOpportunity;
 import tds.student.sql.data.ItemResponseUpdateStatus;
 import tds.student.web.TestManager;
-import AIR.Common.Web.Session.HttpContext;
-import AIR.Common.xml.TdsXmlOutputFactory;
 
 // / <summary>
 // / Used to write out the results of a update response request (or possibly
@@ -62,6 +60,7 @@ public class TestResponseWriter // : IDisposable
     _writer.writeAttribute ("lengthMet", Boolean.toString (tm.IsTestLengthMet ()));
     _writer.writeAttribute ("finished", Boolean.toString (tm.IsTestLengthMet () && pageList.isAllCompleted ()));
     _writer.writeAttribute ("prefetched", Boolean.toString (prefetched));
+    _writer.writeAttribute ("allAnswered", Boolean.toString(pageList.isAllAnswered()));
     // SB:Merge End
     _writer.writeEndElement ();
 


### PR DESCRIPTION
Add 'allanswered' to test results summary for notificiation display change, and bump versions to grab new changes. Will not merge until dependences are released and student points at them.